### PR TITLE
feat: Add support for "null" emote

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@dcl/wearable-preview",
-      "version": "0.1.0",
+      "version": "0.0.0-development",
       "hasInstallScript": true,
       "dependencies": {
         "@babylonjs/core": "^4.2.0",
@@ -14,7 +14,7 @@
         "@babylonjs/inspector": "^4.2.0",
         "@babylonjs/loaders": "^4.2.0",
         "@babylonjs/materials": "^4.2.0",
-        "@dcl/schemas": "^5.3.0",
+        "@dcl/schemas": "^5.4.3",
         "@testing-library/jest-dom": "^5.15.0",
         "@testing-library/react": "^11.2.7",
         "@testing-library/user-event": "^12.8.3",
@@ -1912,9 +1912,9 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "node_modules/@dcl/schemas": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.3.0.tgz",
-      "integrity": "sha512-OslfXpMzrBbgoQvFDeLkvODsD39k8dhrSCz/w9J3NkE6rSgZ3ZgTP9rYyVX/quiFcaXTYrD6Tp33eHechj7KHg==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.4.3.tgz",
+      "integrity": "sha512-FCmkyca+YT3nRBDGA6Kv5tQQBYE486ecju8DuZrJwIgrwEwzqRsuaHoPVkKOLfO/vvDyxcVa3Y5fmYuBtjsT8Q==",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -23006,9 +23006,9 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "@dcl/schemas": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.3.0.tgz",
-      "integrity": "sha512-OslfXpMzrBbgoQvFDeLkvODsD39k8dhrSCz/w9J3NkE6rSgZ3ZgTP9rYyVX/quiFcaXTYrD6Tp33eHechj7KHg==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.4.3.tgz",
+      "integrity": "sha512-FCmkyca+YT3nRBDGA6Kv5tQQBYE486ecju8DuZrJwIgrwEwzqRsuaHoPVkKOLfO/vvDyxcVa3Y5fmYuBtjsT8Q==",
       "requires": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@babylonjs/inspector": "^4.2.0",
     "@babylonjs/loaders": "^4.2.0",
     "@babylonjs/materials": "^4.2.0",
-    "@dcl/schemas": "^5.3.0",
+    "@dcl/schemas": "^5.4.3",
     "@testing-library/jest-dom": "^5.15.0",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",
@@ -50,9 +50,9 @@
       "not op_mini all"
     ],
     "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
     ]
   },
   "prettier": {

--- a/src/lib/babylon/emote.ts
+++ b/src/lib/babylon/emote.ts
@@ -22,40 +22,12 @@ export function buildEmoteUrl(emote: PreviewEmote) {
 }
 
 export async function loadEmoteFromUrl(scene: Scene, url: string) {
-  console.log('url in loadEmoteFromUrl: ', url)
   const container = await loadAssetContainer(scene, url)
   if (container.animationGroups.length === 0) {
     throw new Error(`No animation groups found for emote with url=${url}`)
   }
   return container
 }
-
-// export type EmoteRepresentationDefinition = Omit<EmoteRepresentationADR74, 'contents'> & {
-//   contents: {
-//     key: string
-//     url: string
-//   }[]
-// }
-
-// export type EmoteDefinition = Omit<Emote, 'emoteDataADR74'> & {
-//   emoteDataADR74: Omit<Emote['emoteDataADR74'], 'representations'> & {
-//     representations: EmoteRepresentationDefinition[]
-//   }
-// }
-
-// export async function loadEmoteFromWearable(scene: Scene, wearable: Emote, config: PreviewConfig) {
-//   const representation = getRepresentation(wearable, config.bodyShape) as EmoteRepresentationADR74
-//   console.log('representation: ', representation)
-//   const content = representation.contents.find((content) => content === representation.mainFile)
-//   console.log('content: ', content)
-//   // const content = representation.contents.find((content) => content.key === representation.mainFile)
-//   if (!content) {
-//     throw new Error(
-//       `Could not find a valid content in representation for wearable=${wearable.id} and bodyShape=${config.bodyShape}`
-//     )
-//   }
-//   return loadEmoteFromUrl(scene, content)
-// }
 
 export async function loadEmoteFromWearable(scene: Scene, wearable: EmoteDefinition, config: PreviewConfig) {
   const representation = getRepresentation(wearable, config.bodyShape)

--- a/src/lib/babylon/emote.ts
+++ b/src/lib/babylon/emote.ts
@@ -62,10 +62,7 @@ export async function playEmote(scene: Scene, assets: Asset[], config: PreviewCo
     const emote = config.wearables.reverse().find(isEmote)!
     container = await loadEmoteFromWearable(scene, emote as EmoteDefinition, config)
     //TODO: remove this cast that supports the old emote entity
-    loop =
-      (config.wearable as any).emoteDataV0 !== undefined
-        ? !!(config.wearable as any).emoteDataV0.loop
-        : !!emote.emoteDataADR74?.loop
+    loop = (emote as any).emoteDataV0 !== undefined ? !!(emote as any).emoteDataV0.loop : !!emote.emoteDataADR74?.loop
   }
   if (!container && config.emote) {
     const emoteUrl = buildEmoteUrl(config.emote)

--- a/src/lib/babylon/emote.ts
+++ b/src/lib/babylon/emote.ts
@@ -31,7 +31,7 @@ export async function loadEmoteFromUrl(scene: Scene, url: string) {
 
 export async function loadEmoteFromWearable(scene: Scene, wearable: EmoteDefinition, config: PreviewConfig) {
   const representation = getRepresentation(wearable, config.bodyShape)
-  const content = representation.contents.find((content: any) => content.key === representation.mainFile)
+  const content = representation.contents.find((content) => content.key === representation.mainFile)
   if (!content) {
     throw new Error(
       `Could not find a valid content in representation for wearable=${wearable.id} and bodyShape=${config.bodyShape}`
@@ -49,7 +49,11 @@ export async function playEmote(scene: Scene, assets: Asset[], config: PreviewCo
   if (config.wearable && isEmote(config.wearable)) {
     try {
       container = await loadEmoteFromWearable(scene, config.wearable as EmoteDefinition, config)
-      loop = !!config.wearable.emoteDataADR74.loop
+      //TODO: remove this cast that supports the old emote entity
+      loop =
+        (config.wearable as any).emoteDataV0 !== undefined
+          ? !!(config.wearable as any).emoteDataV0.loop
+          : config.wearable.emoteDataADR74.loop
     } catch (error) {
       console.warn(`Could not load emote=${config.wearable.id}`)
     }
@@ -57,7 +61,11 @@ export async function playEmote(scene: Scene, assets: Asset[], config: PreviewCo
     // if there's some emote in the wearables list, play the last one
     const emote = config.wearables.reverse().find(isEmote)!
     container = await loadEmoteFromWearable(scene, emote as EmoteDefinition, config)
-    loop = !!emote.emoteDataADR74?.loop
+    //TODO: remove this cast that supports the old emote entity
+    loop =
+      (config.wearable as any).emoteDataV0 !== undefined
+        ? !!(config.wearable as any).emoteDataV0.loop
+        : !!emote.emoteDataADR74?.loop
   }
   if (!container && config.emote) {
     const emoteUrl = buildEmoteUrl(config.emote)

--- a/src/lib/babylon/emote.ts
+++ b/src/lib/babylon/emote.ts
@@ -1,5 +1,5 @@
 import { AnimationGroup, ArcRotateCamera, AssetContainer, Scene, TransformNode } from '@babylonjs/core'
-import { IEmoteController, PreviewCamera, PreviewConfig, PreviewEmote, WearableDefinition } from '@dcl/schemas'
+import { IEmoteController, PreviewCamera, PreviewConfig, PreviewEmote, EmoteDefinition } from '@dcl/schemas'
 import { isEmote } from '../emote'
 import { getRepresentation } from '../representation'
 import { startAutoRotateBehavior } from './camera'
@@ -22,6 +22,7 @@ export function buildEmoteUrl(emote: PreviewEmote) {
 }
 
 export async function loadEmoteFromUrl(scene: Scene, url: string) {
+  console.log('url in loadEmoteFromUrl: ', url)
   const container = await loadAssetContainer(scene, url)
   if (container.animationGroups.length === 0) {
     throw new Error(`No animation groups found for emote with url=${url}`)
@@ -29,9 +30,36 @@ export async function loadEmoteFromUrl(scene: Scene, url: string) {
   return container
 }
 
-export async function loadEmoteFromWearable(scene: Scene, wearable: WearableDefinition, config: PreviewConfig) {
+// export type EmoteRepresentationDefinition = Omit<EmoteRepresentationADR74, 'contents'> & {
+//   contents: {
+//     key: string
+//     url: string
+//   }[]
+// }
+
+// export type EmoteDefinition = Omit<Emote, 'emoteDataADR74'> & {
+//   emoteDataADR74: Omit<Emote['emoteDataADR74'], 'representations'> & {
+//     representations: EmoteRepresentationDefinition[]
+//   }
+// }
+
+// export async function loadEmoteFromWearable(scene: Scene, wearable: Emote, config: PreviewConfig) {
+//   const representation = getRepresentation(wearable, config.bodyShape) as EmoteRepresentationADR74
+//   console.log('representation: ', representation)
+//   const content = representation.contents.find((content) => content === representation.mainFile)
+//   console.log('content: ', content)
+//   // const content = representation.contents.find((content) => content.key === representation.mainFile)
+//   if (!content) {
+//     throw new Error(
+//       `Could not find a valid content in representation for wearable=${wearable.id} and bodyShape=${config.bodyShape}`
+//     )
+//   }
+//   return loadEmoteFromUrl(scene, content)
+// }
+
+export async function loadEmoteFromWearable(scene: Scene, wearable: EmoteDefinition, config: PreviewConfig) {
   const representation = getRepresentation(wearable, config.bodyShape)
-  const content = representation.contents.find((content) => content.key === representation.mainFile)
+  const content = representation.contents.find((content: any) => content.key === representation.mainFile)
   if (!content) {
     throw new Error(
       `Could not find a valid content in representation for wearable=${wearable.id} and bodyShape=${config.bodyShape}`
@@ -43,22 +71,23 @@ export async function loadEmoteFromWearable(scene: Scene, wearable: WearableDefi
 export async function playEmote(scene: Scene, assets: Asset[], config: PreviewConfig) {
   // load asset container for emote
   let container: AssetContainer | undefined
-  let loop = isLooped(config.emote)
+  let loop = !!config.emote && isLooped(config.emote)
+
   // if target wearable is emote, play that one
   if (config.wearable && isEmote(config.wearable)) {
     try {
-      container = await loadEmoteFromWearable(scene, config.wearable, config)
-      loop = !!config.wearable.emoteDataV0?.loop
+      container = await loadEmoteFromWearable(scene, config.wearable as EmoteDefinition, config)
+      loop = !!config.wearable.emoteDataADR74.loop
     } catch (error) {
       console.warn(`Could not load emote=${config.wearable.id}`)
     }
   } else if (config.wearables.some(isEmote)) {
     // if there's some emote in the wearables list, play the last one
     const emote = config.wearables.reverse().find(isEmote)!
-    container = await loadEmoteFromWearable(scene, emote, config)
-    loop = !!emote.emoteDataV0?.loop
+    container = await loadEmoteFromWearable(scene, emote as EmoteDefinition, config)
+    loop = !!emote.emoteDataADR74?.loop
   }
-  if (!container) {
+  if (!container && config.emote) {
     const emoteUrl = buildEmoteUrl(config.emote)
     container = await loadEmoteFromUrl(scene, emoteUrl)
   }
@@ -87,7 +116,7 @@ export async function playEmote(scene: Scene, assets: Asset[], config: PreviewCo
         return map.set(node.id, list)
       }, new Map<string, TransformNode[]>())
       // apply each targeted animation from the emote asset container to the transform nodes of all the wearables
-      if (container.animationGroups.length > 0) {
+      if (container && container.animationGroups.length > 0) {
         for (const targetedAnimation of container.animationGroups[0].targetedAnimations) {
           const animation = targetedAnimation.animation
           const target = targetedAnimation.target as TransformNode
@@ -98,8 +127,6 @@ export async function playEmote(scene: Scene, assets: Asset[], config: PreviewCo
             }
           }
         }
-      } else {
-        throw new Error(`No animationGroups found`)
       }
     }
     // play animation group and apply
@@ -123,7 +150,8 @@ function createController(animationGroup: AnimationGroup, loop: boolean): IEmote
   let hasPlayed = false
 
   async function getLength() {
-    return animationGroup.to
+    // if there's no animation, it should return 0
+    return Math.max(animationGroup.to, 0)
   }
 
   async function isPlaying() {

--- a/src/lib/babylon/mappings.ts
+++ b/src/lib/babylon/mappings.ts
@@ -1,9 +1,9 @@
 import { SceneLoader } from '@babylonjs/core'
 import { GLTFFileLoader } from '@babylonjs/loaders'
-import { PreviewConfig, BodyShape, WearableDefinition } from '@dcl/schemas'
+import { PreviewConfig, BodyShape, WearableDefinition, EmoteDefinition } from '@dcl/schemas'
 import { getRepresentation } from '../representation'
 
-export function createMappings(wearables: WearableDefinition[], bodyShape = BodyShape.MALE) {
+export function createMappings(wearables: (WearableDefinition | EmoteDefinition)[], bodyShape = BodyShape.MALE) {
   const mappings: Record<string, string> = {}
   for (const wearable of wearables) {
     try {

--- a/src/lib/babylon/render.ts
+++ b/src/lib/babylon/render.ts
@@ -1,5 +1,6 @@
 import { Color4 } from '@babylonjs/core'
 import { PreviewConfig, PreviewType, BodyShape, IPreviewController, IEmoteController } from '@dcl/schemas'
+import { createInvalidEmoteController, isEmote } from '../emote'
 import { getBodyShape } from './body'
 import { getSlots } from './slots'
 import { playEmote } from './emote'
@@ -8,7 +9,6 @@ import { setupMappings } from './mappings'
 import { Asset, center, createScene } from './scene'
 import { isFacialFeature, isModel, isSuccesful } from './utils'
 import { loadWearable } from './wearable'
-import { createInvalidEmoteController } from '../emote'
 
 /**
  * Initializes Babylon, creates the scene and loads a list of wearables in it
@@ -62,7 +62,7 @@ export async function render(canvas: HTMLCanvasElement, config: PreviewConfig): 
       emoteController = (await playEmote(scene, assets, config)) || createInvalidEmoteController() // default to invalid emote controller if there is an issue with the emote, but let the rest of the preview keep working
     } else {
       const wearable = config.wearable
-      if (wearable) {
+      if (wearable && !isEmote(wearable)) {
         try {
           // try loading with the required body shape
           const asset = await loadWearable(scene, wearable, config.bodyShape, config.skin, config.hair)

--- a/src/lib/babylon/slots.ts
+++ b/src/lib/babylon/slots.ts
@@ -1,5 +1,5 @@
 import { PreviewConfig, WearableCategory, WearableDefinition } from '@dcl/schemas'
-import { hasRepresentation } from '../representation'
+import { hasRepresentation, isWearableDefinition } from '../representation'
 import { isEmote } from '../emote'
 
 const categoriesHiddenBySkin = [
@@ -17,12 +17,12 @@ const categoriesHiddenBySkin = [
 export function getSlots(config: PreviewConfig) {
   const slots = new Map<WearableCategory, WearableDefinition>()
 
-  let wearables: WearableDefinition[] = config.wearables.filter((wearable) => !isEmote(wearable)) // remove emotes if any
+  let wearables = config.wearables.filter((wearable) => !isEmote(wearable)) as WearableDefinition[] // remove emotes if any
 
   // remove other wearables that hide the equipped wearable
   if (config.wearable && !isEmote(config.wearable)) {
-    wearables = config.wearables.filter((wearable) => {
-      if (config.wearable) {
+    wearables = (config.wearables as WearableDefinition[]).filter((wearable) => {
+      if (config.wearable && isWearableDefinition(config.wearable)) {
         const { category, hides, replaces } = config.wearable.data
         if (wearable.data.category === 'skin') {
           if (categoriesHiddenBySkin.includes(category)) {

--- a/src/lib/babylon/utils.ts
+++ b/src/lib/babylon/utils.ts
@@ -1,4 +1,4 @@
-import { WearableCategory, WearableDefinition } from '@dcl/schemas'
+import { RepresentationDefinition, WearableCategory, WearableDefinition } from '@dcl/schemas'
 import { getRepresentationOrDefault, isTexture } from '../representation'
 import { Asset } from './scene'
 
@@ -22,7 +22,7 @@ export function isSuccesful(result: void | Asset): result is Asset {
 
 export function isModel(wearable: WearableDefinition): boolean {
   const representation = getRepresentationOrDefault(wearable)
-  return !isTexture(representation)
+  return !isTexture(representation as RepresentationDefinition)
 }
 
 export function isFacialFeature(wearable: WearableDefinition): boolean {

--- a/src/lib/babylon/wearable.ts
+++ b/src/lib/babylon/wearable.ts
@@ -8,7 +8,7 @@
  */
 
 import { Color3, PBRMaterial, Scene } from '@babylonjs/core'
-import { WearableDefinition, BodyShape } from '@dcl/schemas'
+import { WearableDefinition, BodyShape, RepresentationDefinition } from '@dcl/schemas'
 import { getRepresentation, isTexture, getContentUrl } from '../representation'
 import { loadAssetContainer } from './scene'
 import './toon'
@@ -20,7 +20,7 @@ export async function loadWearable(
   skin?: string,
   hair?: string
 ) {
-  const representation = getRepresentation(wearable, bodyShape)
+  const representation = getRepresentation(wearable, bodyShape) as RepresentationDefinition
   if (isTexture(representation)) {
     throw new Error(`The wearable="${wearable.id}" is a texture`)
   }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -10,6 +10,7 @@ import {
   PreviewOptions,
   PreviewType,
   Rarity,
+  RepresentationDefinition,
   WearableDefinition,
   WearableWithBlobs,
 } from '@dcl/schemas'
@@ -220,7 +221,7 @@ export async function createConfig(options: PreviewOptions = {}): Promise<Previe
 
   if (wearable) {
     zoom = wearables.length > 0 ? zoom : getZoom(wearable)
-    const representation = getRepresentationOrDefault(wearable)
+    const representation = getRepresentationOrDefault(wearable) as RepresentationDefinition
     if (isTexture(representation) && type !== PreviewType.AVATAR) {
       type = PreviewType.TEXTURE
     }
@@ -238,7 +239,7 @@ export async function createConfig(options: PreviewOptions = {}): Promise<Previe
     }
   }
 
-  let emote = PreviewEmote.IDLE
+  let emote = null
   if (options.emote && Object.values(PreviewEmote).includes(options.emote)) {
     emote = options.emote
   }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -239,7 +239,7 @@ export async function createConfig(options: PreviewOptions = {}): Promise<Previe
     }
   }
 
-  let emote = null
+  let emote = options.emote === undefined ? PreviewEmote.IDLE : options.emote
   if (options.emote && Object.values(PreviewEmote).includes(options.emote)) {
     emote = options.emote
   }

--- a/src/lib/emote.ts
+++ b/src/lib/emote.ts
@@ -1,7 +1,8 @@
-import { IEmoteController, WearableDefinition } from '@dcl/schemas'
+import { IEmoteController, WearableDefinition, EmoteDefinition } from '@dcl/schemas'
 
-export function isEmote(wearable: WearableDefinition) {
-  return `emoteDataV0` in wearable
+export function isEmote(wearable: WearableDefinition | EmoteDefinition): wearable is EmoteDefinition {
+  // leaving both until the existing emotes are migrated
+  return 'emoteDataADR74' in wearable || 'emoteDataV0' in wearable
 }
 
 export class InvalidEmoteError extends Error {

--- a/src/lib/representation.ts
+++ b/src/lib/representation.ts
@@ -1,30 +1,53 @@
-import { BodyShape, RepresentationDefinition, WearableDefinition } from '@dcl/schemas'
+import {
+  BodyShape,
+  RepresentationDefinition,
+  WearableDefinition,
+  EmoteDefinition,
+  EmoteRepresentationDefinition,
+} from '@dcl/schemas'
 
-export function is(representation: RepresentationDefinition, bodyShape: BodyShape) {
+export function is(representation: RepresentationDefinition | EmoteRepresentationDefinition, bodyShape: BodyShape) {
   return representation.bodyShapes.includes(bodyShape)
 }
 
-export function isMale(representation: RepresentationDefinition) {
+export function isMale(representation: RepresentationDefinition | EmoteRepresentationDefinition) {
   return is(representation, BodyShape.MALE)
 }
 
-export function isFemale(representation: RepresentationDefinition) {
+export function isFemale(representation: RepresentationDefinition | EmoteRepresentationDefinition) {
   return is(representation, BodyShape.FEMALE)
 }
 
-export function getRepresentation(wearable: WearableDefinition, shape = BodyShape.MALE) {
+export const isWearableDefinition = (
+  definition: WearableDefinition | EmoteDefinition
+): definition is WearableDefinition => !!(definition as WearableDefinition).data
+
+export function getRepresentation(wearable: WearableDefinition | EmoteDefinition, shape = BodyShape.MALE) {
+  const isWearableDef = isWearableDefinition(wearable)
   switch (shape) {
     case BodyShape.FEMALE: {
-      if (!wearable.data.representations.some(isFemale)) {
+      if (
+        isWearableDef
+          ? !wearable.data.representations.some(isFemale)
+          : !wearable.emoteDataADR74.representations.some(isFemale)
+      ) {
         throw new Error(`Could not find a BaseFemale representation for wearable="${wearable.id}"`)
       }
-      return wearable.data.representations.find(isFemale)!
+      return isWearableDef
+        ? wearable.data.representations.find(isFemale)!
+        : wearable.emoteDataADR74.representations.find(isFemale)!
     }
     case BodyShape.MALE: {
-      if (!wearable.data.representations.some(isMale)) {
+      if (
+        isWearableDef
+          ? !wearable.data.representations.some(isMale)
+          : !wearable.emoteDataADR74.representations.some(isMale)
+      ) {
         throw new Error(`Could not find a BaseMale representation for wearable="${wearable.id}"`)
       }
-      return wearable.data.representations.find(isMale)!
+      return isWearableDef
+        ? wearable.data.representations.find(isMale)!
+        : wearable.emoteDataADR74.representations.find(isMale)!
     }
   }
 }
@@ -48,7 +71,7 @@ export function hasRepresentation(wearable: WearableDefinition, shape = BodyShap
   }
 }
 
-export function getContentUrl(representation: RepresentationDefinition) {
+export function getContentUrl(representation: RepresentationDefinition | EmoteRepresentationDefinition) {
   const content = representation.contents.find((content) => content.key === representation.mainFile)
   if (!content) {
     throw new Error(`Could not find main file`)

--- a/src/lib/wearable.ts
+++ b/src/lib/wearable.ts
@@ -1,7 +1,8 @@
-import { BodyShape, WearableCategory, WearableDefinition } from '@dcl/schemas'
+import { BodyShape, EmoteDefinition, WearableCategory, WearableDefinition } from '@dcl/schemas'
+import { isWearableDefinition } from './representation'
 
-export function getWearableByCategory(wearables: WearableDefinition[], category: WearableCategory) {
-  return wearables.find((wearable) => wearable.data.category === category) || null
+export function getWearableByCategory(wearables: (WearableDefinition | EmoteDefinition)[], category: WearableCategory) {
+  return wearables.find((wearable) => isWearableDefinition(wearable) && wearable.data.category === category) || null
 }
 
 export function getFacialFeatureCategories() {


### PR DESCRIPTION
Nowadays, the wearable preview renders the IDLE emote as the default one, that means that it gets loaded before getting the message with the blob with the emote we want to render from the builder. That means that the `getLength` will be emitted twice, once for the idle and another once the blob is parsed.