### PR TITLE
feat: added support for emote events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ yarn-error.log*
 
 .vercel
 .env
+.vscode

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babylonjs/inspector": "^4.2.0",
         "@babylonjs/loaders": "^4.2.0",
         "@babylonjs/materials": "^4.2.0",
-        "@dcl/schemas": "^5.4.4",
+        "@dcl/schemas": "^5.5.0",
         "@testing-library/jest-dom": "^5.15.0",
         "@testing-library/react": "^11.2.7",
         "@testing-library/user-event": "^12.8.3",
@@ -1912,9 +1912,9 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "node_modules/@dcl/schemas": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.4.4.tgz",
-      "integrity": "sha512-I1BGfTtzx+QhpTvRYgYVI6PTfddLHtOaOGt8CwFpBplC4EL9tuTjkmVYxE7x6LtcMMUCLQMaAh3CPF2YNC1ZyA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.5.0.tgz",
+      "integrity": "sha512-XPJ3DYxWKR7gOYxwkqGbzRm4cJCqZ2OkY2v8GJbEgBDUvG9lv1YwKulzWdUbuHrqcpR7bMJjV3Cj812Ri49u9g==",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -23006,9 +23006,9 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "@dcl/schemas": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.4.4.tgz",
-      "integrity": "sha512-I1BGfTtzx+QhpTvRYgYVI6PTfddLHtOaOGt8CwFpBplC4EL9tuTjkmVYxE7x6LtcMMUCLQMaAh3CPF2YNC1ZyA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.5.0.tgz",
+      "integrity": "sha512-XPJ3DYxWKR7gOYxwkqGbzRm4cJCqZ2OkY2v8GJbEgBDUvG9lv1YwKulzWdUbuHrqcpR7bMJjV3Cj812Ri49u9g==",
       "requires": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@babylonjs/inspector": "^4.2.0",
     "@babylonjs/loaders": "^4.2.0",
     "@babylonjs/materials": "^4.2.0",
-    "@dcl/schemas": "^5.4.4",
+    "@dcl/schemas": "^5.5.0",
     "@testing-library/jest-dom": "^5.15.0",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",

--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -6,6 +6,7 @@ import { useConfig } from '../../hooks/useConfig'
 import { useReady } from '../../hooks/useReady'
 import { useController } from '../../hooks/useController'
 import { render } from '../../lib/babylon/render'
+import { handleEmoteEvents } from '../../lib/emote-events'
 import './Preview.css'
 
 const Preview: React.FC = () => {
@@ -51,7 +52,12 @@ const Preview: React.FC = () => {
       } else {
         // preview models
         render(canvasRef.current, config)
-          .then((_controller) => (controller.current = _controller))
+          .then((newController) => {
+            // set new controller as current one
+            controller.current = newController
+            // handle emote events and forward them as messages
+            handleEmoteEvents(controller.current)
+          })
           .catch((error) => setPreviewError(error.message))
           .finally(() => {
             setIsLoadingModel(false)

--- a/src/hooks/useController.ts
+++ b/src/hooks/useController.ts
@@ -1,5 +1,5 @@
 import { useRef } from 'react'
-import { IPreviewController, PreviewMessageType, sendMessage } from '@dcl/schemas'
+import { IPreviewController, PreviewMessagePayload, PreviewMessageType, sendMessage } from '@dcl/schemas'
 import { useMessage } from './useMessage'
 
 function sendResult(id: string, result: any) {
@@ -24,12 +24,8 @@ export const useController = () => {
       typeof event.data.payload.params === 'object' &&
       Array.isArray(event.data.payload.params)
     ) {
-      const { id, method, namespace, params } = event.data.payload as {
-        id: string
-        namespace: string
-        method: string
-        params: any[]
-      }
+      const { id, method, namespace, params } = event.data
+        .payload as PreviewMessagePayload<PreviewMessageType.CONTROLLER_REQUEST>
       if (controllerRef.current) {
         if (namespace in controllerRef.current) {
           if (method in controllerRef.current[namespace as keyof IPreviewController]) {

--- a/src/lib/babylon/emote.ts
+++ b/src/lib/babylon/emote.ts
@@ -1,5 +1,13 @@
+import { EventEmitter } from 'events'
 import { AnimationGroup, ArcRotateCamera, AssetContainer, Scene, TransformNode } from '@babylonjs/core'
-import { IEmoteController, PreviewCamera, PreviewConfig, PreviewEmote, EmoteDefinition } from '@dcl/schemas'
+import {
+  IEmoteController,
+  PreviewCamera,
+  PreviewConfig,
+  PreviewEmote,
+  EmoteDefinition,
+  PreviewEmoteEventType,
+} from '@dcl/schemas'
 import { isEmote } from '../emote'
 import { getRepresentation } from '../representation'
 import { startAutoRotateBehavior } from './camera'
@@ -177,6 +185,14 @@ function createController(animationGroup: AnimationGroup, loop: boolean): IEmote
     }
   }
 
+  const events = new EventEmitter()
+
+  // forward observable events to event emitter
+  animationGroup.onAnimationGroupPlayObservable.add(() => events.emit(PreviewEmoteEventType.ANIMATION_PLAY))
+  animationGroup.onAnimationGroupPauseObservable.add(() => events.emit(PreviewEmoteEventType.ANIMATION_PAUSE))
+  animationGroup.onAnimationGroupLoopObservable.add(() => events.emit(PreviewEmoteEventType.ANIMATION_LOOP))
+  animationGroup.onAnimationGroupEndObservable.add(() => events.emit(PreviewEmoteEventType.ANIMATION_END))
+
   return {
     getLength,
     isPlaying,
@@ -184,5 +200,6 @@ function createController(animationGroup: AnimationGroup, loop: boolean): IEmote
     play,
     pause,
     stop,
+    events,
   }
 }

--- a/src/lib/emote-events.ts
+++ b/src/lib/emote-events.ts
@@ -1,0 +1,14 @@
+import { IPreviewController, PreviewEmoteEventType, PreviewMessageType, sendMessage } from '@dcl/schemas'
+
+export function handleEmoteEvents(controller: IPreviewController) {
+  // handle an emote event by forwarding it as a message
+  function handleEvent(type: PreviewEmoteEventType) {
+    controller.emote.events.on(type, () => sendMessage(window.parent, PreviewMessageType.EMOTE_EVENT, { type }))
+  }
+
+  // handle all emote event types
+  handleEvent(PreviewEmoteEventType.ANIMATION_PLAY)
+  handleEvent(PreviewEmoteEventType.ANIMATION_PAUSE)
+  handleEvent(PreviewEmoteEventType.ANIMATION_LOOP)
+  handleEvent(PreviewEmoteEventType.ANIMATION_END)
+}

--- a/src/lib/emote.ts
+++ b/src/lib/emote.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'events'
 import { IEmoteController, WearableDefinition, EmoteDefinition } from '@dcl/schemas'
 
 export function isEmote(wearable: WearableDefinition | EmoteDefinition): wearable is EmoteDefinition {
@@ -31,5 +32,6 @@ export function createInvalidEmoteController(): IEmoteController {
     stop() {
       throw new InvalidEmoteError()
     },
+    events: new EventEmitter(),
   }
 }


### PR DESCRIPTION
Blocked by https://github.com/decentraland/common-schemas/pull/114

This PR adds support for a new `EMOTE_EVENT` message, which can have different types: `animation_play`, `animation_pause`, `animation_loop` and `animation_end`. These are native observable events in babylon, and they are being forwarded via `postMessage` so they can be handled on the main frame exposed through a regular event emitter.