### PR TITLE
fix: Fix to play the controller when the loaded scene contains an emote

### DIFF
--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -73,7 +73,7 @@ const Preview: React.FC = () => {
       if (isLoaded) {
         sendMessage(window.parent, PreviewMessageType.LOAD, null)
         setIsMessageSent(true)
-        if (config?.camera !== PreviewCamera.STATIC) {
+        if (config?.camera !== PreviewCamera.STATIC && config?.type === PreviewType.AVATAR) {
           controller.current?.emote.play()
         }
       } else if (error) {
@@ -81,7 +81,7 @@ const Preview: React.FC = () => {
         setIsMessageSent(true)
       }
     }
-  }, [isLoaded, error, isMessageSent, controller, config?.camera])
+  }, [isLoaded, error, isMessageSent, controller, config?.camera, config?.type])
 
   // when the config is being loaded again (because the was an update to some of the options) reset all the other loading flags
   useEffect(() => {


### PR DESCRIPTION
This PR fixes the controller play when the loaded scene doesn't contain an emote.