### PR TITLE
fix: mappings for wearables with blobs

### DIFF
--- a/src/lib/babylon/mappings.ts
+++ b/src/lib/babylon/mappings.ts
@@ -32,9 +32,14 @@ export function setupMappings(config: PreviewConfig) {
     if (plugin.name === 'gltf') {
       const gltf = plugin as GLTFFileLoader
       gltf.preprocessUrlAsync = async (url: string) => {
-        const baseUrl = `/content/contents/`
-        const parts = url.split(baseUrl)
-        return parts.length > 0 && !!parts[1] ? mappings[parts[1]] : url
+        const baseUrl = `/`
+        const filename = url.split(baseUrl).pop()
+        if (!filename) {
+          return url
+        }
+        const keys = Object.keys(mappings)
+        const key = keys.find((_key) => _key.endsWith(filename))
+        return mappings[key!] || url
       }
     }
   })


### PR DESCRIPTION
The current logic for mappings only works for wearables that come from the catalyst or the builder server (because it relied on the url having a `content/contents` section), but it doesn't work for wearables with blobs (ie. wearables from a zip file). this PR fixes that.
