### PR TITLE
fix: using the zoom via postMessage

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -30,7 +30,7 @@ import {
   getFacialFeatureCategories,
   getNonFacialFeatureCategories,
 } from './wearable'
-import { getZoom } from './zoom'
+import { computeZoom, getZoom } from './zoom'
 
 const DEFAULT_PROFILE = 'default'
 
@@ -332,7 +332,7 @@ export async function createConfig(options: PreviewOptions = {}): Promise<Previe
     cameraX,
     cameraY,
     cameraZ,
-    zoom: typeof options.zoom === 'number' ? options.zoom : zoom,
+    zoom: typeof options.zoom === 'number' ? computeZoom(options.zoom) : zoom,
     wheelZoom,
     wheelPrecision,
     wheelStart,

--- a/src/lib/zoom.ts
+++ b/src/lib/zoom.ts
@@ -1,10 +1,19 @@
 import { WearableCategory, WearableDefinition } from '@dcl/schemas'
 
+const MIN_ZOOM = 1
+const MAX_ZOOM = 2.8
+const ZOOM_RANGE = MAX_ZOOM - MIN_ZOOM
+
+export function computeZoom(value: number) {
+  const clampedValue = Math.min(Math.max(value, 0), 100)
+  const percentage = clampedValue / 100
+  const zoom = percentage * ZOOM_RANGE + MIN_ZOOM
+  return zoom
+}
+
 export function parseZoom(rawZoom: string | null) {
   const parsedZoom = rawZoom ? parseFloat(rawZoom) : null
-  const zoom =
-    parsedZoom === null || isNaN(parsedZoom) ? null : (Math.min(Math.max(parsedZoom, 0), 100) * 1.8) / 100 + 1
-  return zoom
+  return parsedZoom === null || isNaN(parsedZoom) ? null : parsedZoom
 }
 
 /**


### PR DESCRIPTION
## The Problem

The `zoom` option can be set by the user as a value between 0 and 100. This value is then converted to a value between 1 and 2.8 (which are the actual valid values). The conversion from 0-100 to 1-2.8 range was done when the value was parsed from the query param. This means that when the `zoom` value was passed via `postMessage`, the value would be used as is, instead of converted to the right range, resulting in a huge value and not working as expected.

## The Solution

I moved the logic to convert the value to the right range into a separate function from the parsing, and I used it within the `createConfig` function, which is used either if the update is coming from a query param or from a postMessage update.