### PR TITLE
Fix: Stop loop animations

### DIFF
--- a/src/lib/babylon/emote.ts
+++ b/src/lib/babylon/emote.ts
@@ -127,7 +127,6 @@ export async function playEmote(scene: Scene, assets: Asset[], config: PreviewCo
 
 function createController(animationGroup: AnimationGroup, loop: boolean): IEmoteController {
   let startFrom = 0
-  let hasPlayed = false
 
   async function getLength() {
     // if there's no animation, it should return 0
@@ -160,7 +159,6 @@ function createController(animationGroup: AnimationGroup, loop: boolean): IEmote
       } else {
         animationGroup.play(loop)
       }
-      hasPlayed = true
     }
   }
 
@@ -171,12 +169,9 @@ function createController(animationGroup: AnimationGroup, loop: boolean): IEmote
   }
 
   async function stop() {
-    if (hasPlayed) {
+    if (await isPlaying()) {
       animationGroup.goToFrame(0)
       animationGroup.stop()
-    } else {
-      play()
-      window.requestAnimationFrame(stop)
     }
   }
 

--- a/src/lib/babylon/emote.ts
+++ b/src/lib/babylon/emote.ts
@@ -169,10 +169,8 @@ function createController(animationGroup: AnimationGroup, loop: boolean): IEmote
   }
 
   async function stop() {
-    if (await isPlaying()) {
-      animationGroup.goToFrame(0)
-      animationGroup.stop()
-    }
+    animationGroup.goToFrame(0)
+    animationGroup.stop()
   }
 
   const events = new EventEmitter()

--- a/src/lib/babylon/emote.ts
+++ b/src/lib/babylon/emote.ts
@@ -85,9 +85,6 @@ export async function playEmote(scene: Scene, assets: Asset[], config: PreviewCo
       const camera = scene.cameras[0] as ArcRotateCamera
       startAutoRotateBehavior(camera, config)
     }
-    if (loop) {
-      emoteAnimationGroup.play(true) // keep playing animation in loop
-    }
   }
 
   // play emote animation
@@ -175,8 +172,8 @@ function createController(animationGroup: AnimationGroup, loop: boolean): IEmote
 
   async function stop() {
     if (hasPlayed) {
-      goTo(0)
-      window.requestAnimationFrame(pause)
+      animationGroup.goToFrame(0)
+      animationGroup.stop()
     } else {
       play()
       window.requestAnimationFrame(stop)


### PR DESCRIPTION
This PR updates the stop controller logic and removes the `loop` condition on the event: `onAnimationEnd`.