### PR TITLE
fix: add support for ADR74 emotes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babylonjs/inspector": "^4.2.0",
         "@babylonjs/loaders": "^4.2.0",
         "@babylonjs/materials": "^4.2.0",
-        "@dcl/schemas": "^5.15.0",
+        "@dcl/schemas": "^5.16.0",
         "@dcl/ui-env": "^1.2.0",
         "@testing-library/jest-dom": "^5.15.0",
         "@testing-library/react": "^11.2.7",
@@ -1912,9 +1912,9 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "node_modules/@dcl/schemas": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.15.0.tgz",
-      "integrity": "sha512-zt9Iz8r2e9l8JYsEO8+OWxtlY+RQwQL/EXNJ1DZ71WjTFqSNOJcAKoIyCMGKUwh84jSptlw+pYD29copESWwCw==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.16.0.tgz",
+      "integrity": "sha512-DQGbVopUt35lMdoWM/vAcsLy7vh/zCjTABOB4S1fvOI093sH3GVdVkz5ifcfMyxrWuOd0FM0VBcOzRWkRzb76w==",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -22987,9 +22987,9 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "@dcl/schemas": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.15.0.tgz",
-      "integrity": "sha512-zt9Iz8r2e9l8JYsEO8+OWxtlY+RQwQL/EXNJ1DZ71WjTFqSNOJcAKoIyCMGKUwh84jSptlw+pYD29copESWwCw==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.16.0.tgz",
+      "integrity": "sha512-DQGbVopUt35lMdoWM/vAcsLy7vh/zCjTABOB4S1fvOI093sH3GVdVkz5ifcfMyxrWuOd0FM0VBcOzRWkRzb76w==",
       "requires": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@babylonjs/inspector": "^4.2.0",
     "@babylonjs/loaders": "^4.2.0",
     "@babylonjs/materials": "^4.2.0",
-    "@dcl/schemas": "^5.15.0",
+    "@dcl/schemas": "^5.16.0",
     "@dcl/ui-env": "^1.2.0",
     "@testing-library/jest-dom": "^5.15.0",
     "@testing-library/react": "^11.2.7",

--- a/src/lib/api/peer.ts
+++ b/src/lib/api/peer.ts
@@ -14,6 +14,13 @@ import { isEmote } from '../emote'
 import { json } from '../json'
 import { isWearable } from '../wearable'
 
+/**
+ * This converts representations into representation definitions. The difference is representations have contents: string[] and representation definitions have contents: { key: string, url: string}[]
+ * @param entity
+ * @param representations
+ * @param peerUrl
+ * @returns representation definitions
+ */
 function mapEntityRepresentationToDefinition<T extends RepresentationDefinition | EmoteRepresentationDefinition>(
   entity: Entity,
   representations: (EmoteRepresentationADR74 | WearableRepresentation)[],
@@ -28,7 +35,13 @@ function mapEntityRepresentationToDefinition<T extends RepresentationDefinition 
   })) as T[]
 }
 
-function entitytoDefinition<T extends WearableDefinition | EmoteDefinition>(entity: Entity, peerUrl: string): T {
+/**
+ * This converts an entity into a wearable or an emote definition
+ * @param entity
+ * @param peerUrl
+ * @returns a wearable or emote definition
+ */
+function entityToDefinition<T extends WearableDefinition | EmoteDefinition>(entity: Entity, peerUrl: string): T {
   const metadata = entity.metadata as Wearable | Emote
 
   if ('emoteDataADR74' in metadata) {
@@ -62,27 +75,36 @@ function entitytoDefinition<T extends WearableDefinition | EmoteDefinition>(enti
 }
 
 class PeerApi {
+  /**
+   * @param pointers List of pointers
+   * @param peerUrl The url of a catalyst
+   * @returns List of active entities for given pointers
+   */
   async fetchEntities(pointers: string[], peerUrl: string) {
     if (pointers.length === 0) {
       return []
     }
-    const entities = await json<Entity[]>((fetch) =>
-      fetch(`${peerUrl}/content/entities/active`, {
-        method: 'post',
-        body: JSON.stringify({ pointers }),
-        headers: { 'Content-Type': 'application/json' },
-      })
-    )
+    const entities = await json<Entity[]>(`${peerUrl}/content/entities/active`, {
+      method: 'post',
+      body: JSON.stringify({ pointers }),
+      headers: { 'Content-Type': 'application/json' },
+    })
     return entities
   }
 
+  /**
+   *
+   * @param urns List of urns for wearables or emotes
+   * @param peerUrl The url of a Catalyst
+   * @returns List of wearables and list of emotes for given urns
+   */
   async fetchItems(urns: string[], peerUrl: string): Promise<[WearableDefinition[], EmoteDefinition[]]> {
     if (urns.length === 0) {
       return [[], []]
     }
     const pointers = urns.map((urn) => urn.toLowerCase()) // this hack is necessary for body shape urns to work, since they have upper case letter and the catalyst can't find them
     const entities = await this.fetchEntities(pointers, peerUrl)
-    const definitions = entities.map((entity) => entitytoDefinition(entity, peerUrl))
+    const definitions = entities.map((entity) => entityToDefinition(entity, peerUrl))
     const wearables = definitions.filter(isWearable)
     const emotes = definitions.filter(isEmote)
     return [wearables, emotes]

--- a/src/lib/api/peer.ts
+++ b/src/lib/api/peer.ts
@@ -94,7 +94,7 @@ class PeerApi {
   }
 
   /**
-   *
+   * Fetches the entities represented by the given urns and processes them into Wearable and Emote definitions.
    * @param urns List of urns for wearables or emotes
    * @param peerUrl The url of a Catalyst
    * @returns List of wearables and list of emotes for given urns

--- a/src/lib/api/peer.ts
+++ b/src/lib/api/peer.ts
@@ -1,19 +1,80 @@
-import { Profile, WearableDefinition } from '@dcl/schemas'
+import {
+  Profile,
+  WearableDefinition,
+  EmoteDefinition,
+  Entity,
+  Emote,
+  Wearable,
+  EmoteRepresentationADR74,
+  WearableRepresentation,
+  EmoteRepresentationDefinition,
+  RepresentationDefinition,
+} from '@dcl/schemas'
 import { json } from '../json'
 
+function mapEntityRepresentationToDefinition<T extends RepresentationDefinition | EmoteRepresentationDefinition>(
+  entity: Entity,
+  representations: (EmoteRepresentationADR74 | WearableRepresentation)[],
+  peerUrl: string
+): T[] {
+  return representations.map((representation) => ({
+    ...representation,
+    contents: representation.contents.map((key) => ({
+      key,
+      url: `${peerUrl}/content/contents/${entity.content.find((c) => c.file === key)!.hash}`,
+    })),
+  })) as T[]
+}
+
+function entitytoDefinition<T extends WearableDefinition | EmoteDefinition>(entity: Entity, peerUrl: string): T {
+  const metadata = entity.metadata as Wearable | Emote
+
+  if ('emoteDataADR74' in metadata) {
+    const definition: EmoteDefinition = {
+      ...metadata,
+      emoteDataADR74: {
+        ...metadata.emoteDataADR74,
+        representations: mapEntityRepresentationToDefinition<EmoteRepresentationDefinition>(
+          entity,
+          metadata.emoteDataADR74.representations,
+          peerUrl
+        ),
+      },
+    }
+    return definition as T
+  }
+
+  const definition: WearableDefinition = {
+    ...metadata,
+    data: {
+      ...metadata.data,
+      representations: mapEntityRepresentationToDefinition<RepresentationDefinition>(
+        entity,
+        metadata.data.representations,
+        peerUrl
+      ),
+    },
+  }
+
+  return definition as T
+}
+
 class PeerApi {
-  async fetchWearables(urns: string[], peerUrl: string) {
+  async fetchItems(urns: string[], peerUrl: string): Promise<(WearableDefinition | EmoteDefinition)[]> {
     if (urns.length === 0) {
       return []
     }
-    const { wearables } = await json<{ wearables: WearableDefinition[] }>(
-      `${peerUrl}/lambdas/collections/wearables?${urns.map((urn) => `wearableId=${urn}`).join('&')}`
+    const entities = await json<Entity[]>((fetch) =>
+      fetch(`${peerUrl}/content/entities/active`, {
+        method: 'post',
+        body: JSON.stringify({ pointers: urns }),
+        headers: { 'Content-Type': 'application/json' },
+      })
     )
-    if (wearables.length === 0) {
-      throw new Error(`Wearables not found for urns="${urns}"`)
-    }
-    return wearables
+    const definitions = entities.map((entity) => entitytoDefinition(entity, peerUrl))
+    return definitions
   }
+
   async fetchProfile(profile: string, peerUrl: string) {
     const profiles = await json<Profile[]>(`${peerUrl}/lambdas/profiles?id=${profile}`)
     return profiles.length > 0 ? profiles[0] : null

--- a/src/lib/api/peer.ts
+++ b/src/lib/api/peer.ts
@@ -36,7 +36,7 @@ function mapEntityRepresentationToDefinition<T extends RepresentationDefinition 
 }
 
 /**
- * This converts an entity into a wearable or an emote definition
+ * Converts an entity into a wearable or an emote definition.
  * @param entity
  * @param peerUrl
  * @returns a wearable or emote definition

--- a/src/lib/api/peer.ts
+++ b/src/lib/api/peer.ts
@@ -76,6 +76,7 @@ function entityToDefinition<T extends WearableDefinition | EmoteDefinition>(enti
 
 class PeerApi {
   /**
+   * Fetches the entities that represent the given pointers.
    * @param pointers List of pointers
    * @param peerUrl The url of a catalyst
    * @returns List of active entities for given pointers

--- a/src/lib/api/peer.ts
+++ b/src/lib/api/peer.ts
@@ -15,7 +15,7 @@ import { json } from '../json'
 import { isWearable } from '../wearable'
 
 /**
- * This converts representations into representation definitions. The difference is representations have contents: string[] and representation definitions have contents: { key: string, url: string}[]
+ * Converts representations into representation definitions. Representations have contents as string[] and representation definitions have contents as { key: string, url: string}[].
  * @param entity
  * @param representations
  * @param peerUrl

--- a/src/lib/babylon/render.ts
+++ b/src/lib/babylon/render.ts
@@ -61,7 +61,7 @@ export async function render(canvas: HTMLCanvasElement, config: PreviewConfig): 
       // play emote
       emoteController = (await playEmote(scene, assets, config)) || createInvalidEmoteController() // default to invalid emote controller if there is an issue with the emote, but let the rest of the preview keep working
     } else {
-      const wearable = config.wearable
+      const wearable = config.item
       if (wearable && !isEmote(wearable)) {
         try {
           // try loading with the required body shape

--- a/src/lib/babylon/scene.ts
+++ b/src/lib/babylon/scene.ts
@@ -29,7 +29,7 @@ import {
 } from '@dcl/schemas'
 import { hexToColor } from '../color'
 import { isIOs } from '../env'
-import { getRepresentation } from '../representation'
+import { getWearableRepresentation } from '../representation'
 import { createSceneController } from '../scene'
 import { startAutoRotateBehavior } from './camera'
 
@@ -179,7 +179,7 @@ export async function loadMask(
   bodyShape: BodyShape
 ): Promise<Texture | null> {
   const name = wearable.id
-  const representation = getRepresentation(wearable, bodyShape)
+  const representation = getWearableRepresentation(wearable, bodyShape)
   const file = representation.contents.find((file) => file.key.toLowerCase().endsWith('_mask.png'))
   if (file) {
     return new Promise((resolve, reject) => {
@@ -200,7 +200,7 @@ export async function loadTexture(
   bodyShape: BodyShape
 ): Promise<Texture | null> {
   const name = wearable.id
-  const representation = getRepresentation(wearable, bodyShape)
+  const representation = getWearableRepresentation(wearable, bodyShape)
   const file = representation.contents.find(
     (file) => file.key.toLowerCase().endsWith('.png') && !file.key.toLowerCase().endsWith('_mask.png')
   )

--- a/src/lib/babylon/slots.ts
+++ b/src/lib/babylon/slots.ts
@@ -1,6 +1,7 @@
 import { PreviewConfig, WearableCategory, WearableDefinition } from '@dcl/schemas'
-import { hasRepresentation, isWearableDefinition } from '../representation'
+import { hasRepresentation } from '../representation'
 import { isEmote } from '../emote'
+import { isWearable } from '../wearable'
 
 const categoriesHiddenBySkin = [
   WearableCategory.HELMET,
@@ -22,7 +23,7 @@ export function getSlots(config: PreviewConfig) {
   // remove other wearables that hide the equipped wearable
   if (config.wearable && !isEmote(config.wearable)) {
     wearables = (config.wearables as WearableDefinition[]).filter((wearable) => {
-      if (config.wearable && isWearableDefinition(config.wearable)) {
+      if (config.wearable && isWearable(config.wearable)) {
         const { category, hides, replaces } = config.wearable.data
         if (wearable.data.category === 'skin') {
           if (categoriesHiddenBySkin.includes(category)) {

--- a/src/lib/babylon/slots.ts
+++ b/src/lib/babylon/slots.ts
@@ -1,6 +1,5 @@
 import { PreviewConfig, WearableCategory, WearableDefinition } from '@dcl/schemas'
-import { hasRepresentation } from '../representation'
-import { isEmote } from '../emote'
+import { hasWearableRepresentation } from '../representation'
 import { isWearable } from '../wearable'
 
 const categoriesHiddenBySkin = [
@@ -18,41 +17,41 @@ const categoriesHiddenBySkin = [
 export function getSlots(config: PreviewConfig) {
   const slots = new Map<WearableCategory, WearableDefinition>()
 
-  let wearables = config.wearables.filter((wearable) => !isEmote(wearable)) as WearableDefinition[] // remove emotes if any
+  let wearables: WearableDefinition[] = [...config.wearables]
 
   // remove other wearables that hide the equipped wearable
-  if (config.wearable && !isEmote(config.wearable)) {
-    wearables = (config.wearables as WearableDefinition[]).filter((wearable) => {
-      if (config.wearable && isWearable(config.wearable)) {
-        const { category, hides, replaces } = config.wearable.data
-        if (wearable.data.category === 'skin') {
-          if (categoriesHiddenBySkin.includes(category)) {
-            return false
-          }
-          if (hides && hides.includes(WearableCategory.HEAD)) {
-            return false
-          }
-          if (replaces && replaces.includes(WearableCategory.HEAD)) {
-            return false
-          }
+  if (config.item && isWearable(config.item)) {
+    wearables = []
+    for (const wearable of config.wearables) {
+      const { category, hides, replaces } = config.item.data
+      if (wearable.data.category === 'skin') {
+        if (categoriesHiddenBySkin.includes(category)) {
+          continue
         }
-        if (wearable.data.hides && wearable.data.hides.includes(category)) {
-          return false
+        if (hides && hides.includes(WearableCategory.HEAD)) {
+          continue
         }
-        if (wearable.data.replaces && wearable.data.replaces.includes(category)) {
-          return false
+        if (replaces && replaces.includes(WearableCategory.HEAD)) {
+          continue
         }
       }
-      return true
-    })
+      if (wearable.data.hides && wearable.data.hides.includes(category)) {
+        continue
+      }
+      if (wearable.data.replaces && wearable.data.replaces.includes(category)) {
+        continue
+      }
+      // add wearable if not hidden or replaced
+      wearables.push(wearable)
+    }
     // add the equipped wearable at the end
-    wearables.push(config.wearable)
+    wearables.push(config.item)
   }
 
   // arrange wearbles in slots
   for (const wearable of wearables) {
     const slot = wearable.data.category
-    if (hasRepresentation(wearable, config.bodyShape)) {
+    if (hasWearableRepresentation(wearable, config.bodyShape)) {
       slots.set(slot, wearable)
     }
   }

--- a/src/lib/babylon/utils.ts
+++ b/src/lib/babylon/utils.ts
@@ -1,5 +1,5 @@
 import { RepresentationDefinition, WearableCategory, WearableDefinition } from '@dcl/schemas'
-import { getRepresentationOrDefault, isTexture } from '../representation'
+import { getWearableRepresentationOrDefault, isTexture } from '../representation'
 import { Asset } from './scene'
 
 export function isCategory(category: WearableCategory) {
@@ -21,7 +21,7 @@ export function isSuccesful(result: void | Asset): result is Asset {
 }
 
 export function isModel(wearable: WearableDefinition): boolean {
-  const representation = getRepresentationOrDefault(wearable)
+  const representation = getWearableRepresentationOrDefault(wearable)
   return !isTexture(representation as RepresentationDefinition)
 }
 

--- a/src/lib/babylon/wearable.ts
+++ b/src/lib/babylon/wearable.ts
@@ -9,7 +9,7 @@
 
 import { Color3, PBRMaterial, Scene } from '@babylonjs/core'
 import { WearableDefinition, BodyShape, RepresentationDefinition } from '@dcl/schemas'
-import { getRepresentation, isTexture, getContentUrl } from '../representation'
+import { getWearableRepresentation, isTexture, getContentUrl } from '../representation'
 import { loadAssetContainer } from './scene'
 import './toon'
 
@@ -20,7 +20,7 @@ export async function loadWearable(
   skin?: string,
   hair?: string
 ) {
-  const representation = getRepresentation(wearable, bodyShape) as RepresentationDefinition
+  const representation = getWearableRepresentation(wearable, bodyShape) as RepresentationDefinition
   if (isTexture(representation)) {
     throw new Error(`The wearable="${wearable.id}" is a texture`)
   }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -64,12 +64,11 @@ async function fetchProfileWearables(profile: Avatar | null, peerUrl: string) {
   return wearables
 }
 
-async function fetchURNs(urns: string[], peerUrl: string) {
+async function fetchURNs(urns: string[], peerUrl: string): Promise<[WearableDefinition[], EmoteDefinition[]]> {
   if (urns.length === 0) {
-    return []
+    return [[], []]
   }
-  const results = await peerApi.fetchItems(urns, peerUrl)
-  return results
+  return peerApi.fetchItems(urns, peerUrl)
 }
 
 async function fetchWearableURNs(urns: string[], peerUrl: string) {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,6 +1,7 @@
 import {
   Avatar,
   BodyShape,
+  EmoteDefinition,
   isStandard,
   Network,
   PreviewCamera,
@@ -55,14 +56,15 @@ async function fetchProfileWearables(profile: Avatar | null, peerUrl: string) {
     return []
   }
   const results = await fetchURNs(profile.avatar.wearables, peerUrl)
-  return results.filter((result) => !isEmote(result))
+  return results.filter((result) => !isEmote(result)) as WearableDefinition[]
 }
 
 async function fetchURNs(urns: string[], peerUrl: string) {
   if (urns.length === 0) {
     return []
   }
-  return peerApi.fetchWearables(urns, peerUrl)
+  const results = await peerApi.fetchItems(urns, peerUrl)
+  return results
 }
 
 async function fetchURLs(urls: string[]) {
@@ -163,7 +165,7 @@ async function fetchAvatar(
     wearables = [...wearables, ...defaultWearables]
   }
 
-  return wearables
+  return wearables as WearableDefinition[]
 }
 
 export async function createConfig(options: PreviewOptions = {}): Promise<PreviewConfig> {
@@ -173,7 +175,7 @@ export async function createConfig(options: PreviewOptions = {}): Promise<Previe
   const nftServerUrl = options.nftServerUrl || config.get('NFT_SERVER_URL')
 
   // load wearable to preview
-  let wearablePromise: Promise<WearableDefinition | void> = Promise.resolve()
+  let wearablePromise: Promise<WearableDefinition | EmoteDefinition | void> = Promise.resolve()
   if (contractAddress) {
     wearablePromise = fetchWearableFromContract({ contractAddress, tokenId, itemId, peerUrl, nftServerUrl })
   }

--- a/src/lib/emote.ts
+++ b/src/lib/emote.ts
@@ -1,9 +1,9 @@
 import { EventEmitter } from 'events'
 import { IEmoteController, WearableDefinition, EmoteDefinition } from '@dcl/schemas'
 
-export function isEmote(wearable: WearableDefinition | EmoteDefinition): wearable is EmoteDefinition {
-  // leaving both until the existing emotes are migrated
-  return 'emoteDataADR74' in wearable || 'emoteDataV0' in wearable
+export function isEmote(definition: WearableDefinition | EmoteDefinition | void): definition is EmoteDefinition {
+  // TODO: Remove the emoteDataV0 part after migration
+  return !!definition && ('emoteDataADR74' in definition || 'emoteDataV0' in definition)
 }
 
 export class InvalidEmoteError extends Error {

--- a/src/lib/json.ts
+++ b/src/lib/json.ts
@@ -1,11 +1,8 @@
 import { sleep } from './sleep'
 
-export async function json<T>(
-  url: string | ((_fetch: typeof fetch) => ReturnType<typeof fetch>),
-  attempts = 3
-): Promise<T> {
+export async function json<T>(url: string, options: RequestInit = {}, attempts = 3): Promise<T> {
   try {
-    const resp = typeof url === 'string' ? await fetch(url) : await url(fetch)
+    const resp = await fetch(url, options)
     if (!resp.ok) {
       throw new Error(await resp.text())
     }
@@ -13,7 +10,7 @@ export async function json<T>(
   } catch (error) {
     if (attempts > 0) {
       await sleep(100)
-      return json(url, attempts - 1)
+      return json(url, options, attempts - 1)
     } else {
       throw error
     }

--- a/src/lib/json.ts
+++ b/src/lib/json.ts
@@ -1,8 +1,11 @@
 import { sleep } from './sleep'
 
-export async function json<T>(url: string, attempts = 3): Promise<T> {
+export async function json<T>(
+  url: string | ((_fetch: typeof fetch) => ReturnType<typeof fetch>),
+  attempts = 3
+): Promise<T> {
   try {
-    const resp = await fetch(url)
+    const resp = typeof url === 'string' ? await fetch(url) : await url(fetch)
     if (!resp.ok) {
       throw new Error(await resp.text())
     }

--- a/src/lib/representation.ts
+++ b/src/lib/representation.ts
@@ -1,79 +1,68 @@
-import {
-  BodyShape,
-  RepresentationDefinition,
-  WearableDefinition,
-  EmoteDefinition,
-  EmoteRepresentationDefinition,
-} from '@dcl/schemas'
-import { isEmote } from './emote'
-import { isWearable } from './wearable'
+import { BodyShape, EmoteDefinition, RepresentationDefinition, WearableDefinition } from '@dcl/schemas'
 
-export function is(representation: RepresentationDefinition | EmoteRepresentationDefinition, bodyShape: BodyShape) {
+export function is(representation: RepresentationDefinition, bodyShape: BodyShape) {
   return representation.bodyShapes.includes(bodyShape)
 }
 
-export function isMale(representation: RepresentationDefinition | EmoteRepresentationDefinition) {
+export function isMale(representation: RepresentationDefinition) {
   return is(representation, BodyShape.MALE)
 }
 
-export function isFemale(representation: RepresentationDefinition | EmoteRepresentationDefinition) {
+export function isFemale(representation: RepresentationDefinition) {
   return is(representation, BodyShape.FEMALE)
 }
 
-export function getRepresentation(wearable: WearableDefinition | EmoteDefinition, shape = BodyShape.MALE) {
-  const isWearableDefinition = isWearable(wearable)
-  switch (shape) {
+export function getEmoteRepresentation(emote: EmoteDefinition, bodyShape = BodyShape.MALE) {
+  // TODO: Remove the emoteDataV0 part after migration
+  if ((emote as unknown as WearableDefinition).emoteDataV0) {
+    return (emote as unknown as WearableDefinition).data.representations[0]
+  }
+  const representation = emote.emoteDataADR74.representations.find((representation) =>
+    representation.bodyShapes.includes(bodyShape)
+  )
+  if (!representation) {
+    throw new Error(`Could not find a representation of bodyShape=${bodyShape} for emote="${emote.id}"`)
+  }
+  return representation
+}
+
+export function getWearableRepresentation(wearable: WearableDefinition, bodyShape = BodyShape.MALE) {
+  switch (bodyShape) {
     case BodyShape.FEMALE: {
-      if (
-        isWearableDefinition
-          ? !wearable.data.representations.some(isFemale)
-          : !wearable.emoteDataADR74.representations.some(isFemale)
-      ) {
+      if (!wearable.data.representations.some(isFemale)) {
         throw new Error(`Could not find a BaseFemale representation for wearable="${wearable.id}"`)
       }
-      return isWearableDefinition
-        ? wearable.data.representations.find(isFemale)!
-        : wearable.emoteDataADR74.representations.find(isFemale)!
+      return wearable.data.representations.find(isFemale)!
     }
     case BodyShape.MALE: {
-      if (
-        isWearableDefinition
-          ? !wearable.data.representations.some(isMale)
-          : !wearable.emoteDataADR74.representations.some(isMale)
-      ) {
+      if (!wearable.data.representations.some(isMale)) {
         throw new Error(`Could not find a BaseMale representation for wearable="${wearable.id}"`)
       }
-      return isWearableDefinition
-        ? wearable.data.representations.find(isMale)!
-        : wearable.emoteDataADR74.representations.find(isMale)!
+      return wearable.data.representations.find(isMale)!
     }
   }
 }
 
-export function getRepresentationOrDefault(definition: WearableDefinition | EmoteDefinition, shape = BodyShape.MALE) {
-  if (hasRepresentation(definition, shape)) {
-    return getRepresentation(definition, shape)
+export function getWearableRepresentationOrDefault(definition: WearableDefinition, shape = BodyShape.MALE) {
+  if (hasWearableRepresentation(definition, shape)) {
+    return getWearableRepresentation(definition, shape)
   }
-  if (isEmote(definition)) {
-    if (definition.emoteDataADR74.representations.length > 0) {
-      return definition.emoteDataADR74.representations[0]
-    }
-  } else if (definition.data.representations.length > 0) {
+  if (definition.data.representations.length > 0) {
     return definition.data.representations[0]
   }
   throw new Error(`The wearable="${definition.id}" has no representation`)
 }
 
-export function hasRepresentation(definition: WearableDefinition | EmoteDefinition, shape = BodyShape.MALE) {
+export function hasWearableRepresentation(definition: WearableDefinition, shape = BodyShape.MALE) {
   try {
-    getRepresentation(definition, shape)
+    getWearableRepresentation(definition, shape)
     return true
   } catch (error) {
     return false
   }
 }
 
-export function getContentUrl(representation: RepresentationDefinition | EmoteRepresentationDefinition) {
+export function getContentUrl(representation: RepresentationDefinition) {
   const content = representation.contents.find((content) => content.key === representation.mainFile)
   if (!content) {
     throw new Error(`Could not find main file`)

--- a/src/lib/representation.ts
+++ b/src/lib/representation.ts
@@ -5,6 +5,7 @@ import {
   EmoteDefinition,
   EmoteRepresentationDefinition,
 } from '@dcl/schemas'
+import { isEmote } from './emote'
 
 export function is(representation: RepresentationDefinition | EmoteRepresentationDefinition, bodyShape: BodyShape) {
   return representation.bodyShapes.includes(bodyShape)
@@ -52,19 +53,23 @@ export function getRepresentation(wearable: WearableDefinition | EmoteDefinition
   }
 }
 
-export function getRepresentationOrDefault(wearable: WearableDefinition, shape = BodyShape.MALE) {
-  if (hasRepresentation(wearable, shape)) {
-    return getRepresentation(wearable, shape)
+export function getRepresentationOrDefault(definition: WearableDefinition | EmoteDefinition, shape = BodyShape.MALE) {
+  if (hasRepresentation(definition, shape)) {
+    return getRepresentation(definition, shape)
   }
-  if (wearable.data.representations.length > 0) {
-    return wearable.data.representations[0]
+  if (isEmote(definition)) {
+    if (definition.emoteDataADR74.representations.length > 0) {
+      return definition.emoteDataADR74.representations[0]
+    }
+  } else if (definition.data.representations.length > 0) {
+    return definition.data.representations[0]
   }
-  throw new Error(`The wearable="${wearable.id}" has no representation`)
+  throw new Error(`The wearable="${definition.id}" has no representation`)
 }
 
-export function hasRepresentation(wearable: WearableDefinition, shape = BodyShape.MALE) {
+export function hasRepresentation(definition: WearableDefinition | EmoteDefinition, shape = BodyShape.MALE) {
   try {
-    getRepresentation(wearable, shape)
+    getRepresentation(definition, shape)
     return true
   } catch (error) {
     return false

--- a/src/lib/representation.ts
+++ b/src/lib/representation.ts
@@ -6,6 +6,7 @@ import {
   EmoteRepresentationDefinition,
 } from '@dcl/schemas'
 import { isEmote } from './emote'
+import { isWearable } from './wearable'
 
 export function is(representation: RepresentationDefinition | EmoteRepresentationDefinition, bodyShape: BodyShape) {
   return representation.bodyShapes.includes(bodyShape)
@@ -19,34 +20,30 @@ export function isFemale(representation: RepresentationDefinition | EmoteReprese
   return is(representation, BodyShape.FEMALE)
 }
 
-export const isWearableDefinition = (
-  definition: WearableDefinition | EmoteDefinition
-): definition is WearableDefinition => !!(definition as WearableDefinition).data
-
 export function getRepresentation(wearable: WearableDefinition | EmoteDefinition, shape = BodyShape.MALE) {
-  const isWearableDef = isWearableDefinition(wearable)
+  const isWearableDefinition = isWearable(wearable)
   switch (shape) {
     case BodyShape.FEMALE: {
       if (
-        isWearableDef
+        isWearableDefinition
           ? !wearable.data.representations.some(isFemale)
           : !wearable.emoteDataADR74.representations.some(isFemale)
       ) {
         throw new Error(`Could not find a BaseFemale representation for wearable="${wearable.id}"`)
       }
-      return isWearableDef
+      return isWearableDefinition
         ? wearable.data.representations.find(isFemale)!
         : wearable.emoteDataADR74.representations.find(isFemale)!
     }
     case BodyShape.MALE: {
       if (
-        isWearableDef
+        isWearableDefinition
           ? !wearable.data.representations.some(isMale)
           : !wearable.emoteDataADR74.representations.some(isMale)
       ) {
         throw new Error(`Could not find a BaseMale representation for wearable="${wearable.id}"`)
       }
-      return isWearableDef
+      return isWearableDefinition
         ? wearable.data.representations.find(isMale)!
         : wearable.emoteDataADR74.representations.find(isMale)!
     }

--- a/src/lib/representation.ts
+++ b/src/lib/representation.ts
@@ -29,16 +29,18 @@ export function getEmoteRepresentation(emote: EmoteDefinition, bodyShape = BodyS
 export function getWearableRepresentation(wearable: WearableDefinition, bodyShape = BodyShape.MALE) {
   switch (bodyShape) {
     case BodyShape.FEMALE: {
-      if (!wearable.data.representations.some(isFemale)) {
+      const female = wearable.data.representations.find(isFemale)
+      if (!female) {
         throw new Error(`Could not find a BaseFemale representation for wearable="${wearable.id}"`)
       }
-      return wearable.data.representations.find(isFemale)!
+      return female
     }
     case BodyShape.MALE: {
-      if (!wearable.data.representations.some(isMale)) {
+      const male = wearable.data.representations.find(isMale)!
+      if (!male) {
         throw new Error(`Could not find a BaseMale representation for wearable="${wearable.id}"`)
       }
-      return wearable.data.representations.find(isMale)!
+      return male
     }
   }
 }

--- a/src/lib/urn.ts
+++ b/src/lib/urn.ts
@@ -1,0 +1,6 @@
+export function isBodyShape(urn: string) {
+  return (
+    urn.startsWith('urn:decentraland:off-chain:base-avatars:') &&
+    (urn.endsWith('BaseMale') || urn.endsWith('BaseFemale'))
+  )
+}

--- a/src/lib/wearable.ts
+++ b/src/lib/wearable.ts
@@ -1,4 +1,5 @@
 import { BodyShape, EmoteDefinition, WearableCategory, WearableDefinition } from '@dcl/schemas'
+import { isEmote } from './emote'
 import { isWearableDefinition } from './representation'
 
 export function getWearableByCategory(wearables: (WearableDefinition | EmoteDefinition)[], category: WearableCategory) {
@@ -64,11 +65,14 @@ export function isWearable(value: WearableDefinition | void): value is WearableD
   return !!value
 }
 
-export function getBodyShape(wearabe: WearableDefinition): BodyShape {
+export function getBodyShape(definition: WearableDefinition | EmoteDefinition): BodyShape {
   const bodyShapes = [BodyShape.MALE, BodyShape.FEMALE]
+  if (isEmote(definition)) {
+    return bodyShapes[0]
+  }
   return (
     bodyShapes.find((bodyShape) =>
-      wearabe.data.representations.some((representation) => representation.bodyShapes.includes(bodyShape))
+      definition.data.representations.some((representation) => representation.bodyShapes.includes(bodyShape))
     ) || bodyShapes[0]
   )
 }

--- a/src/lib/wearable.ts
+++ b/src/lib/wearable.ts
@@ -1,9 +1,8 @@
 import { BodyShape, EmoteDefinition, WearableCategory, WearableDefinition } from '@dcl/schemas'
 import { isEmote } from './emote'
-import { isWearableDefinition } from './representation'
 
 export function getWearableByCategory(wearables: (WearableDefinition | EmoteDefinition)[], category: WearableCategory) {
-  return wearables.find((wearable) => isWearableDefinition(wearable) && wearable.data.category === category) || null
+  return wearables.find((wearable) => isWearable(wearable) && wearable.data.category === category) || null
 }
 
 export function getFacialFeatureCategories() {
@@ -61,8 +60,8 @@ export function getDefaultWearableUrn(category: WearableCategory, shape: BodySha
   }
 }
 
-export function isWearable(value: WearableDefinition | void): value is WearableDefinition {
-  return !!value
+export function isWearable(value: WearableDefinition | EmoteDefinition | void): value is WearableDefinition {
+  return !!value && 'data' in value
 }
 
 export function getBodyShape(definition: WearableDefinition | EmoteDefinition): BodyShape {

--- a/src/lib/wearable.ts
+++ b/src/lib/wearable.ts
@@ -1,8 +1,7 @@
 import { BodyShape, EmoteDefinition, WearableCategory, WearableDefinition } from '@dcl/schemas'
-import { isEmote } from './emote'
 
-export function getWearableByCategory(wearables: (WearableDefinition | EmoteDefinition)[], category: WearableCategory) {
-  return wearables.find((wearable) => isWearable(wearable) && wearable.data.category === category) || null
+export function getWearableByCategory(wearables: WearableDefinition[], category: WearableCategory) {
+  return wearables.find((wearable) => wearable.data.category === category) || null
 }
 
 export function getFacialFeatureCategories() {
@@ -64,11 +63,8 @@ export function isWearable(value: WearableDefinition | EmoteDefinition | void): 
   return !!value && 'data' in value
 }
 
-export function getBodyShape(definition: WearableDefinition | EmoteDefinition): BodyShape {
+export function getBodyShape(definition: WearableDefinition): BodyShape {
   const bodyShapes = [BodyShape.MALE, BodyShape.FEMALE]
-  if (isEmote(definition)) {
-    return bodyShapes[0]
-  }
   return (
     bodyShapes.find((bodyShape) =>
       definition.data.representations.some((representation) => representation.bodyShapes.includes(bodyShape))

--- a/src/lib/wearable.ts
+++ b/src/lib/wearable.ts
@@ -1,4 +1,5 @@
 import { BodyShape, EmoteDefinition, WearableCategory, WearableDefinition } from '@dcl/schemas'
+import { isEmote } from './emote'
 
 export function getWearableByCategory(wearables: WearableDefinition[], category: WearableCategory) {
   return wearables.find((wearable) => wearable.data.category === category) || null
@@ -60,7 +61,7 @@ export function getDefaultWearableUrn(category: WearableCategory, shape: BodySha
 }
 
 export function isWearable(value: WearableDefinition | EmoteDefinition | void): value is WearableDefinition {
-  return !!value && 'data' in value
+  return !!value && 'data' in value && !isEmote(value)
 }
 
 export function getBodyShape(definition: WearableDefinition): BodyShape {

--- a/src/lib/zoom.ts
+++ b/src/lib/zoom.ts
@@ -1,4 +1,5 @@
-import { WearableCategory, WearableDefinition } from '@dcl/schemas'
+import { EmoteDefinition, WearableCategory, WearableDefinition } from '@dcl/schemas'
+import { isEmote } from './emote'
 
 const MIN_ZOOM = 1
 const MAX_ZOOM = 2.8
@@ -21,8 +22,8 @@ export function parseZoom(rawZoom: string | null) {
  * @param category
  * @returns
  */
-export function getZoom(wearable?: WearableDefinition | void) {
-  const category = wearable?.data.category
+export function getZoom(wearable?: WearableDefinition | EmoteDefinition | void) {
+  const category = !wearable || isEmote(wearable) ? null : wearable?.data.category
   switch (category) {
     case WearableCategory.UPPER_BODY:
       return 2

--- a/src/lib/zoom.ts
+++ b/src/lib/zoom.ts
@@ -22,8 +22,8 @@ export function parseZoom(rawZoom: string | null) {
  * @param category
  * @returns
  */
-export function getZoom(wearable?: WearableDefinition | EmoteDefinition | void) {
-  const category = !wearable || isEmote(wearable) ? null : wearable?.data.category
+export function getZoom(item?: WearableDefinition | EmoteDefinition | void) {
+  const category = item && isEmote(item) ? null : item?.data.category
   switch (category) {
     case WearableCategory.UPPER_BODY:
       return 2


### PR DESCRIPTION
This PR adds support for emotes that are of `EntityType.EMOTE` and with the schema of the ADR-74. In order to support this, instead of using the lambdas, we fetch the entities and then convert them to wearable or emote definitions. This is because we can't fetch wearable and emote definitions from the same lambda, and we need to be able to get these definitions from the URNs, and by looking just at the URNs we cannot tell if they are wearables or emotes. So since we can't tell beforehand what they are, we can't know which lambda to hit. So instead we use the `content/entities/active` endpoint and fetch the entities by pointer (which is the URN). 

Then I refactored the `config.wearables` prop to be just a `WearableDefinition[]` instead of a mix of `WearableDefinition` and `EmoteDefinition`. This simplified several parts of the code where we needed to check the type of an item.

Some test cases:

- Legacy emote "Spotlight" from fashion week (first batch of emotes), stored in wearable format, live in production: 
  -  ✅ Works on current wearable preview: https://wearable-preview.decentraland.org/?env=prod&contract=0x875146d1d26e91c80f25f5966a84b098d3db1fc8&item=2
  -  ✅ Works on this PR: https://wearable-preview-9j7f8ajwj-decentraland1.vercel.app/?env=prod&contract=0x875146d1d26e91c80f25f5966a84b098d3db1fc8&item=2

- New emote "Dab", stored as emote entity with ADR74 format, in goerli: 
  - ❌ Does not work on current wearable-preview: https://wearable-preview.decentraland.org/?env=dev&contract=0x917eea3e9879050158ab4a3613f3dbd44294c9e8&item=0
  - ✅ Works on this PR: https://wearable-preview-9j7f8ajwj-decentraland1.vercel.app/?env=dev&contract=0x917eea3e9879050158ab4a3613f3dbd44294c9e8&item=0
