### PR TITLE
fix: Play emotes when camera is static

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,5 +190,3 @@ npm run start
 ```
 npm run build
 ```
-
-.

--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import classNames from 'classnames'
-import { PreviewCamera, PreviewType, PreviewMessageType, sendMessage } from '@dcl/schemas'
+import { PreviewCamera, PreviewType, PreviewMessageType, sendMessage, PreviewEmote } from '@dcl/schemas'
 import { useWindowSize } from '../../hooks/useWindowSize'
 import { useConfig } from '../../hooks/useConfig'
 import { useReady } from '../../hooks/useReady'
@@ -73,7 +73,7 @@ const Preview: React.FC = () => {
       if (isLoaded) {
         sendMessage(window.parent, PreviewMessageType.LOAD, null)
         setIsMessageSent(true)
-        if (config?.camera !== PreviewCamera.STATIC && config?.type === PreviewType.AVATAR) {
+        if (config?.type === PreviewType.AVATAR || config?.emote !== PreviewEmote.IDLE) {
           controller.current?.emote.play()
         }
       } else if (error) {
@@ -81,7 +81,7 @@ const Preview: React.FC = () => {
         setIsMessageSent(true)
       }
     }
-  }, [isLoaded, error, isMessageSent, controller, config?.camera, config?.type])
+  }, [isLoaded, error, isMessageSent, controller, config?.type, config?.emote])
 
   // when the config is being loaded again (because the was an update to some of the options) reset all the other loading flags
   useEffect(() => {

--- a/src/lib/api/peer.ts
+++ b/src/lib/api/peer.ts
@@ -44,9 +44,14 @@ function mapEntityRepresentationToDefinition<T extends RepresentationDefinition 
 function entityToDefinition<T extends WearableDefinition | EmoteDefinition>(entity: Entity, peerUrl: string): T {
   const metadata = entity.metadata as Wearable | Emote
 
+  // this is used for the image and the thumbnail urls
+  const lambdaBaseUrl = `${peerUrl}/lambdas/collections/contents/${entity.metadata.id}`
+
   if ('emoteDataADR74' in metadata) {
     const definition: EmoteDefinition = {
       ...metadata,
+      thumbnail: `${lambdaBaseUrl}/thumbnail`,
+      image: `${lambdaBaseUrl}/image`,
       emoteDataADR74: {
         ...metadata.emoteDataADR74,
         representations: mapEntityRepresentationToDefinition<EmoteRepresentationDefinition>(
@@ -61,6 +66,8 @@ function entityToDefinition<T extends WearableDefinition | EmoteDefinition>(enti
 
   const definition: WearableDefinition = {
     ...metadata,
+    thumbnail: `${lambdaBaseUrl}/thumbnail`,
+    image: `${lambdaBaseUrl}/image`,
     data: {
       ...metadata.data,
       representations: mapEntityRepresentationToDefinition<RepresentationDefinition>(


### PR DESCRIPTION
Currently, the emotes are not playing when the camera is static.