### PR TITLE
feat: support blobs that are ADR74 emotes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babylonjs/inspector": "^4.2.0",
         "@babylonjs/loaders": "^4.2.0",
         "@babylonjs/materials": "^4.2.0",
-        "@dcl/schemas": "^5.16.0",
+        "@dcl/schemas": "^5.17.1",
         "@dcl/ui-env": "^1.2.0",
         "@testing-library/jest-dom": "^5.15.0",
         "@testing-library/react": "^11.2.7",
@@ -1912,9 +1912,9 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "node_modules/@dcl/schemas": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.16.0.tgz",
-      "integrity": "sha512-DQGbVopUt35lMdoWM/vAcsLy7vh/zCjTABOB4S1fvOI093sH3GVdVkz5ifcfMyxrWuOd0FM0VBcOzRWkRzb76w==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.17.1.tgz",
+      "integrity": "sha512-4UgDwSOQOfu+n2iHz/0qOwRqBH+/6aC7O/2LYCr0/sbT54RDiAc0sks3iJyFI9qR7+mFaxT1GCCCQaeRJWMvMg==",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -22987,9 +22987,9 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "@dcl/schemas": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.16.0.tgz",
-      "integrity": "sha512-DQGbVopUt35lMdoWM/vAcsLy7vh/zCjTABOB4S1fvOI093sH3GVdVkz5ifcfMyxrWuOd0FM0VBcOzRWkRzb76w==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.17.1.tgz",
+      "integrity": "sha512-4UgDwSOQOfu+n2iHz/0qOwRqBH+/6aC7O/2LYCr0/sbT54RDiAc0sks3iJyFI9qR7+mFaxT1GCCCQaeRJWMvMg==",
       "requires": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@babylonjs/inspector": "^4.2.0",
     "@babylonjs/loaders": "^4.2.0",
     "@babylonjs/materials": "^4.2.0",
-    "@dcl/schemas": "^5.16.0",
+    "@dcl/schemas": "^5.17.1",
     "@dcl/ui-env": "^1.2.0",
     "@testing-library/jest-dom": "^5.15.0",
     "@testing-library/react": "^11.2.7",

--- a/src/lib/api/peer.ts
+++ b/src/lib/api/peer.ts
@@ -8,7 +8,7 @@ import {
   EmoteRepresentationADR74,
   WearableRepresentation,
   EmoteRepresentationDefinition,
-  RepresentationDefinition,
+  WearableRepresentationDefinition,
 } from '@dcl/schemas'
 import { isEmote } from '../emote'
 import { json } from '../json'
@@ -21,11 +21,9 @@ import { isWearable } from '../wearable'
  * @param peerUrl
  * @returns representation definitions
  */
-function mapEntityRepresentationToDefinition<T extends RepresentationDefinition | EmoteRepresentationDefinition>(
-  entity: Entity,
-  representations: (EmoteRepresentationADR74 | WearableRepresentation)[],
-  peerUrl: string
-): T[] {
+function mapEntityRepresentationToDefinition<
+  T extends WearableRepresentationDefinition | EmoteRepresentationDefinition
+>(entity: Entity, representations: (EmoteRepresentationADR74 | WearableRepresentation)[], peerUrl: string): T[] {
   return representations.map((representation) => ({
     ...representation,
     contents: representation.contents.map((key) => ({
@@ -70,7 +68,7 @@ function entityToDefinition<T extends WearableDefinition | EmoteDefinition>(enti
     image: `${lambdaBaseUrl}/image`,
     data: {
       ...metadata.data,
-      representations: mapEntityRepresentationToDefinition<RepresentationDefinition>(
+      representations: mapEntityRepresentationToDefinition<WearableRepresentationDefinition>(
         entity,
         metadata.data.representations,
         peerUrl

--- a/src/lib/babylon/utils.ts
+++ b/src/lib/babylon/utils.ts
@@ -1,4 +1,4 @@
-import { RepresentationDefinition, WearableCategory, WearableDefinition } from '@dcl/schemas'
+import { WearableCategory, WearableDefinition } from '@dcl/schemas'
 import { getWearableRepresentationOrDefault, isTexture } from '../representation'
 import { Asset } from './scene'
 
@@ -22,7 +22,7 @@ export function isSuccesful(result: void | Asset): result is Asset {
 
 export function isModel(wearable: WearableDefinition): boolean {
   const representation = getWearableRepresentationOrDefault(wearable)
-  return !isTexture(representation as RepresentationDefinition)
+  return !isTexture(representation)
 }
 
 export function isFacialFeature(wearable: WearableDefinition): boolean {

--- a/src/lib/babylon/wearable.ts
+++ b/src/lib/babylon/wearable.ts
@@ -8,7 +8,7 @@
  */
 
 import { Color3, PBRMaterial, Scene } from '@babylonjs/core'
-import { WearableDefinition, BodyShape, RepresentationDefinition } from '@dcl/schemas'
+import { WearableDefinition, BodyShape } from '@dcl/schemas'
 import { getWearableRepresentation, isTexture, getContentUrl } from '../representation'
 import { loadAssetContainer } from './scene'
 import './toon'
@@ -20,7 +20,7 @@ export async function loadWearable(
   skin?: string,
   hair?: string
 ) {
-  const representation = getWearableRepresentation(wearable, bodyShape) as RepresentationDefinition
+  const representation = getWearableRepresentation(wearable, bodyShape)
   if (isTexture(representation)) {
     throw new Error(`The wearable="${wearable.id}" is a texture`)
   }

--- a/src/lib/representation.ts
+++ b/src/lib/representation.ts
@@ -1,14 +1,14 @@
-import { BodyShape, EmoteDefinition, RepresentationDefinition, WearableDefinition } from '@dcl/schemas'
+import { BodyShape, EmoteDefinition, WearableRepresentationDefinition, WearableDefinition } from '@dcl/schemas'
 
-export function is(representation: RepresentationDefinition, bodyShape: BodyShape) {
+export function is(representation: WearableRepresentationDefinition, bodyShape: BodyShape) {
   return representation.bodyShapes.includes(bodyShape)
 }
 
-export function isMale(representation: RepresentationDefinition) {
+export function isMale(representation: WearableRepresentationDefinition) {
   return is(representation, BodyShape.MALE)
 }
 
-export function isFemale(representation: RepresentationDefinition) {
+export function isFemale(representation: WearableRepresentationDefinition) {
   return is(representation, BodyShape.FEMALE)
 }
 
@@ -64,7 +64,7 @@ export function hasWearableRepresentation(definition: WearableDefinition, shape 
   }
 }
 
-export function getContentUrl(representation: RepresentationDefinition) {
+export function getContentUrl(representation: WearableRepresentationDefinition) {
   const content = representation.contents.find((content) => content.key === representation.mainFile)
   if (!content) {
     throw new Error(`Could not find main file`)
@@ -72,6 +72,6 @@ export function getContentUrl(representation: RepresentationDefinition) {
   return content.url
 }
 
-export function isTexture(representation: RepresentationDefinition) {
+export function isTexture(representation: WearableRepresentationDefinition) {
   return representation.mainFile.endsWith('png')
 }


### PR DESCRIPTION
This PR adds support for `EmoteWithBlobs` to be passed via the `options.blob` property. Up until now we do support passing emotes as blobs but they are passed as `WearableWithBlobs` type, with an `emoteDataV0` property. This property will eventually be deprecated, so the right way to pass emotes should be as `EmoteWithBlobs`.