### PR TITLE
chore: remove support for legacy emotes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babylonjs/inspector": "^4.2.0",
         "@babylonjs/loaders": "^4.2.0",
         "@babylonjs/materials": "^4.2.0",
-        "@dcl/schemas": "^5.17.1",
+        "@dcl/schemas": "^5.18.1",
         "@dcl/ui-env": "^1.2.0",
         "@testing-library/jest-dom": "^5.15.0",
         "@testing-library/react": "^11.2.7",
@@ -1912,9 +1912,9 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "node_modules/@dcl/schemas": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.17.1.tgz",
-      "integrity": "sha512-4UgDwSOQOfu+n2iHz/0qOwRqBH+/6aC7O/2LYCr0/sbT54RDiAc0sks3iJyFI9qR7+mFaxT1GCCCQaeRJWMvMg==",
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.18.1.tgz",
+      "integrity": "sha512-u5F9STn8qSKGfjNp2R70muQ9Oi6dKWxWwcxNX0rINauDd4jSyEhnUtXcJlw0gmNupORupUtXVaB436Xjnok2Xw==",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -22987,9 +22987,9 @@
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
     "@dcl/schemas": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.17.1.tgz",
-      "integrity": "sha512-4UgDwSOQOfu+n2iHz/0qOwRqBH+/6aC7O/2LYCr0/sbT54RDiAc0sks3iJyFI9qR7+mFaxT1GCCCQaeRJWMvMg==",
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-5.18.1.tgz",
+      "integrity": "sha512-u5F9STn8qSKGfjNp2R70muQ9Oi6dKWxWwcxNX0rINauDd4jSyEhnUtXcJlw0gmNupORupUtXVaB436Xjnok2Xw==",
       "requires": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@babylonjs/inspector": "^4.2.0",
     "@babylonjs/loaders": "^4.2.0",
     "@babylonjs/materials": "^4.2.0",
-    "@dcl/schemas": "^5.17.1",
+    "@dcl/schemas": "^5.18.1",
     "@dcl/ui-env": "^1.2.0",
     "@testing-library/jest-dom": "^5.15.0",
     "@testing-library/react": "^11.2.7",

--- a/src/lib/babylon/emote.ts
+++ b/src/lib/babylon/emote.ts
@@ -7,7 +7,6 @@ import {
   PreviewEmote,
   EmoteDefinition,
   PreviewEmoteEventType,
-  WearableDefinition,
 } from '@dcl/schemas'
 import { isEmote } from '../emote'
 import { startAutoRotateBehavior } from './camera'
@@ -58,11 +57,7 @@ export async function playEmote(scene: Scene, assets: Asset[], config: PreviewCo
   if (config.item && isEmote(config.item)) {
     try {
       container = await loadEmoteFromWearable(scene, config.item as EmoteDefinition, config)
-      // TODO: Remove the emoteDataV0 part after migration
-      loop =
-        (config.item as unknown as WearableDefinition).emoteDataV0 !== undefined
-          ? !!(config.item as unknown as WearableDefinition).emoteDataV0!.loop
-          : config.item.emoteDataADR74.loop
+      loop = config.item.emoteDataADR74.loop
     } catch (error) {
       console.warn(`Could not load emote=${config.item.id}`)
     }

--- a/src/lib/emote.ts
+++ b/src/lib/emote.ts
@@ -2,8 +2,7 @@ import { EventEmitter } from 'events'
 import { IEmoteController, WearableDefinition, EmoteDefinition } from '@dcl/schemas'
 
 export function isEmote(definition: WearableDefinition | EmoteDefinition | void): definition is EmoteDefinition {
-  // TODO: Remove the emoteDataV0 part after migration
-  return !!definition && ('emoteDataADR74' in definition || 'emoteDataV0' in definition)
+  return !!definition && 'emoteDataADR74' in definition
 }
 
 export class InvalidEmoteError extends Error {

--- a/src/lib/representation.ts
+++ b/src/lib/representation.ts
@@ -13,10 +13,6 @@ export function isFemale(representation: WearableRepresentationDefinition) {
 }
 
 export function getEmoteRepresentation(emote: EmoteDefinition, bodyShape = BodyShape.MALE) {
-  // TODO: Remove the emoteDataV0 part after migration
-  if ((emote as unknown as WearableDefinition).emoteDataV0) {
-    return (emote as unknown as WearableDefinition).data.representations[0]
-  }
   const representation = emote.emoteDataADR74.representations.find((representation) =>
     representation.bodyShapes.includes(bodyShape)
   )


### PR DESCRIPTION
Remove support for `emoteDataV0`