### PR TITLE
feat: support scene models

### DIFF
--- a/src/lib/babylon/wearable.ts
+++ b/src/lib/babylon/wearable.ts
@@ -27,6 +27,14 @@ export async function loadWearable(
   const url = getContentUrl(representation)
   const container = await loadAssetContainer(scene, url)
 
+  // Remove colliders
+  for (const mesh of container.meshes) {
+    if (mesh.name.toLowerCase().includes('collider')) {
+      mesh.isVisible = false
+      scene.removeMesh(mesh)
+    }
+  }
+
   // Clean up
   for (const originalMaterial of container.materials) {
     if (originalMaterial instanceof PBRMaterial) {

--- a/src/lib/scene.ts
+++ b/src/lib/scene.ts
@@ -41,9 +41,11 @@ export function createSceneController(engine: Engine, scene: Scene, camera: ArcR
   }
 
   async function getMetrics() {
-    const triangles = scene.meshes.reduce((total, mesh) => {
-      return total + Math.floor(mesh.getTotalIndices() / 3)
-    }, 0)
+    const triangles = scene.meshes
+      .filter((mesh) => !mesh.name.toLowerCase().includes('collider')) // remove colliders from metrics
+      .reduce((total, mesh) => {
+        return total + Math.floor(mesh.getTotalIndices() / 3)
+      }, 0)
     const materials = scene.materials.length
     const meshes = scene.meshes.length
     const textures = scene.textures.filter(


### PR DESCRIPTION
This PR adds support to be able to preview models froms scenes. These models can have a `collider` mesh that should not be rendered and should not be counted towards the metrics