### PR TITLE
fix: Starting emote frame when looping from a GoTo

### DIFF
--- a/src/lib/babylon/emote.ts
+++ b/src/lib/babylon/emote.ts
@@ -214,7 +214,9 @@ function createController(animationGroup: AnimationGroup, loop: boolean): IEmote
   animationGroup.onAnimationGroupEndObservable.add(() => {
     // Send the last frame when the animation ends and the event: end is not emitted by a goTo
     clearEmitPlayingEvent()
-    fromGoTo = false
+    if (!loop) {
+      fromGoTo = false
+    }
     return events.emit(PreviewEmoteEventType.ANIMATION_END)
   })
 


### PR DESCRIPTION
This PR fixes the starting frame when a looped emote ends and was used the Go To feature.