### PR TITLE
fix: Change deprecated endpoint

### DIFF
--- a/src/lib/api/peer.ts
+++ b/src/lib/api/peer.ts
@@ -20,8 +20,11 @@ class PeerApi {
     return wearables
   }
   async fetchProfile(profile: string, env: PreviewEnv) {
-    const profiles = await json<Profile[]>(`${peerByEnv[env]}/lambdas/profiles?id=${profile}`)
-    return profiles.length > 0 ? profiles[0] : null
+    try {
+      return await json<Profile>(`${peerByEnv[env]}/lambdas/profiles/${profile}`)
+    } catch (error) {
+      return null
+    }
   }
 }
 


### PR DESCRIPTION
This PR changes the lambas profile endpoint that uses query parameters to get the profiles, which will be deprecated, for the endpoint that receives the id of the profile via parameter.