### PR TITLE
fix: emote rendering

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -288,7 +288,7 @@ export async function createConfig(options: PreviewOptions = {}): Promise<Previe
     }
   }
 
-  let emote = options.disableDefaultEmotes ? null : options.emote ? options.emote : PreviewEmote.IDLE
+  let emote = options.disableDefaultEmotes || isEmote(item) ? null : options.emote ? options.emote : PreviewEmote.IDLE
   if (options.emote && Object.values(PreviewEmote).includes(options.emote)) {
     emote = options.emote
   }


### PR DESCRIPTION
Some emotes are not being rendered correctly are they are setting the default position of wearables in 0,0,0.

This PRs removes the logic of setting an emote in the config when we are rendering a specific remote

New
https://wearable-preview-git-fix-emote-rendering-decentraland1.vercel.app/?contract=0x705652b66a12dcf782b0b3d5673fbf0c1797eba2&item=17&profile=default&emote=fashion-2
https://wearable-preview-git-fix-emote-rendering-decentraland1.vercel.app/?contract=0x6f8026ecc425d548ea2f953b471b7440780d505b&item=0
https://wearable-preview-git-fix-emote-rendering-decentraland1.vercel.app/?contract=0x9a9b2acf09adca5f626113ff6fa74050a3645044&item=0

 Before
https://wearable-preview.decentraland.org/?contract=0x705652b66a12dcf782b0b3d5673fbf0c1797eba2&item=17&profile=default&emote=fashion-2
https://wearable-preview.decentraland.org/?contract=0x6f8026ecc425d548ea2f953b471b7440780d505b&item=0
https://wearable-preview.decentraland.org/?contract=0x9a9b2acf09adca5f626113ff6fa74050a3645044&item=0
