### PR TITLE
fix: prop animation running in loop

### DIFF
--- a/src/lib/babylon/emote.ts
+++ b/src/lib/babylon/emote.ts
@@ -87,6 +87,9 @@ export async function playEmote(scene: Scene, assets: Asset[], config: PreviewCo
 
   if (container && container.animationGroups.length > 1) {
     container.addAllToScene()
+    // In some cases, the prop animation will start playing on loop when laoded, event though the avatar
+    // animation is not running. This is to stop all possible animations before creating emote animation group
+    scene.stopAllAnimations()
   }
 
   const emoteAnimationGroup = new AnimationGroup('emote', scene)


### PR DESCRIPTION
For some reason, props animations where being loaded and played on loop. This PR stops all animations before create the emote animationGroup that will be in charge of playing and stoping animations using the controller events
Previously
https://wearable-preview.decentraland.org/?profile=default&urn=urn:decentraland:off-chain:base-avatars:keanu_hair&urn=urn:decentraland:off-chain:base-avatars:f_blue_elegant_shirt&urn=urn:decentraland:off-chain:base-avatars:f_yoga_trousers&skin=ffddbb&hair=8b2014&eyes=5e3831&bodyShape=urn:decentraland:off-chain:base-avatars:BaseFemale&emote=idle&wheelZoom=1.5&wheelStart=100&disableBackground&disableAutoRotate&env=dev&urn=urn:decentraland:mumbai:collections-v2:0xcf55d86aee32fe0073be7706c8a8a48b091611f7:0