### PR TITLE
feat: disable default wearables when there is an avatar

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -258,7 +258,7 @@ export async function createConfig(options: PreviewOptions = {}): Promise<Previe
       urls,
       base64s,
       bodyShape,
-      !options.disableDefaultWearables,
+      !options.disableDefaultWearables && !profile?.avatar,
       !options.disableFace,
       peerUrl
     )


### PR DESCRIPTION
When a profile is defined and that profile has an avatar then we are disabling the default wearables to be up to date with "Body fallback" in [ADR-239](https://adr.decentraland.org/adr/ADR-239)