### PR TITLE
fix: change node space size

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -41,3 +41,4 @@ jobs:
           gitlab-pipeline-url: ${{ secrets.GITLAB_CDN_DEPLOYER_URL }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_OPTIONS: --max_old_space_size=8192


### PR DESCRIPTION
Fix `Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory` error