### PR TITLE
fix: prop animation without bone link

### DIFF
--- a/src/lib/babylon/emote.ts
+++ b/src/lib/babylon/emote.ts
@@ -122,11 +122,15 @@ export async function playEmote(scene: Scene, assets: Asset[], config: PreviewCo
           for (const targetedAnimation of animationGroup.targetedAnimations) {
             const animation = targetedAnimation.animation
             const target = targetedAnimation.target as TransformNode
-            const newTargets = nodes.get(target.id)
-            if (newTargets && newTargets.length > 0) {
-              for (const newTarget of newTargets) {
-                emoteAnimationGroup.addTargetedAnimation(animation, newTarget)
+            if (animationGroup.name.includes('Avatar') || container.animationGroups.length === 1) {
+              const newTargets = nodes.get(target.id)
+              if (newTargets && newTargets.length > 0) {
+                for (const newTarget of newTargets) {
+                  emoteAnimationGroup.addTargetedAnimation(animation, newTarget)
+                }
               }
+            } else {
+              emoteAnimationGroup.addTargetedAnimation(animation, target)
             }
           }
         }


### PR DESCRIPTION
Prop animations can be created without bones. We are currently checking that the target of the animation is any of the avialable nodes of the avatar causing it to not work. This PR ignores that check for props animation group