### PR TITLE
feat: Use Events library for Emote events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,9 @@
         "typescript": "^4.4.4",
         "web-vitals": "^1.1.2"
       },
+      "devDependencies": {
+        "@foxify/events": "^2.1.0"
+      },
       "engines": {
         "node": "18"
       }
@@ -2074,6 +2077,12 @@
         "react": "^16.8.0 || ^17",
         "react-dom": "^16.8.0 || ^17"
       }
+    },
+    "node_modules/@foxify/events": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@foxify/events/-/events-2.1.0.tgz",
+      "integrity": "sha512-aMLFeeQgzAH/ft9VNGwQasr2lAXLIxk1VAYIUDM9G8HQX0yow6b7z/wm42e4s6JHU8zGu940sLj5FeglkFnEFQ==",
+      "dev": true
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.2",
@@ -23343,6 +23352,12 @@
         "@babel/runtime": "^7.10.4",
         "react-is": "^16.6.3"
       }
+    },
+    "@foxify/events": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@foxify/events/-/events-2.1.0.tgz",
+      "integrity": "sha512-aMLFeeQgzAH/ft9VNGwQasr2lAXLIxk1VAYIUDM9G8HQX0yow6b7z/wm42e4s6JHU8zGu940sLj5FeglkFnEFQ==",
+      "dev": true
     },
     "@gar/promisify": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "decentraland-ui": "^3.49.0",
         "deep-equal": "^2.0.5",
         "fp-future": "^1.0.1",
+        "mitt": "^3.0.1",
         "prettier": "^2.4.1",
         "raw-loader": "^4.0.2",
         "react": "^17.0.2",
@@ -34,9 +35,6 @@
         "react-scripts": "4.0.3",
         "typescript": "^4.4.4",
         "web-vitals": "^1.1.2"
-      },
-      "devDependencies": {
-        "@foxify/events": "^2.1.0"
       },
       "engines": {
         "node": "18"
@@ -2077,12 +2075,6 @@
         "react": "^16.8.0 || ^17",
         "react-dom": "^16.8.0 || ^17"
       }
-    },
-    "node_modules/@foxify/events": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@foxify/events/-/events-2.1.0.tgz",
-      "integrity": "sha512-aMLFeeQgzAH/ft9VNGwQasr2lAXLIxk1VAYIUDM9G8HQX0yow6b7z/wm42e4s6JHU8zGu940sLj5FeglkFnEFQ==",
-      "dev": true
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.2",
@@ -13846,6 +13838,11 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
+    },
     "node_modules/mixin-deep": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
@@ -23353,12 +23350,6 @@
         "react-is": "^16.6.3"
       }
     },
-    "@foxify/events": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@foxify/events/-/events-2.1.0.tgz",
-      "integrity": "sha512-aMLFeeQgzAH/ft9VNGwQasr2lAXLIxk1VAYIUDM9G8HQX0yow6b7z/wm42e4s6JHU8zGu940sLj5FeglkFnEFQ==",
-      "dev": true
-    },
     "@gar/promisify": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.2.tgz",
@@ -32339,6 +32330,11 @@
         "stream-each": "^1.1.0",
         "through2": "^2.0.0"
       }
+    },
+    "mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
     },
     "mixin-deep": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "decentraland-ui": "^3.49.0",
     "deep-equal": "^2.0.5",
     "fp-future": "^1.0.1",
+    "mitt": "^3.0.1",
     "prettier": "^2.4.1",
     "raw-loader": "^4.0.2",
     "react": "^17.0.2",
@@ -65,8 +66,5 @@
     "singleQuote": true,
     "printWidth": 120
   },
-  "homepage": "",
-  "devDependencies": {
-    "@foxify/events": "^2.1.0"
-  }
+  "homepage": ""
 }

--- a/package.json
+++ b/package.json
@@ -65,5 +65,8 @@
     "singleQuote": true,
     "printWidth": 120
   },
-  "homepage": ""
+  "homepage": "",
+  "devDependencies": {
+    "@foxify/events": "^2.1.0"
+  }
 }

--- a/src/lib/babylon/emote.ts
+++ b/src/lib/babylon/emote.ts
@@ -1,4 +1,4 @@
-import EventEmitter from '@foxify/events'
+import mitt from 'mitt'
 import {
   AnimationGroup,
   ArcRotateCamera,
@@ -247,14 +247,14 @@ function createController(animationGroup: AnimationGroup, loop: boolean, sound: 
 
   // Temporary typed events.
   type Events = {
-    [PreviewEmoteEventType.ANIMATION_PLAY]: () => unknown
-    [PreviewEmoteEventType.ANIMATION_PAUSE]: () => unknown
-    [PreviewEmoteEventType.ANIMATION_LOOP]: () => unknown
-    [PreviewEmoteEventType.ANIMATION_END]: () => unknown
-    [PreviewEmoteEventType.ANIMATION_PLAYING]: ({ length }: { length: number }) => unknown
+    [PreviewEmoteEventType.ANIMATION_PLAY]: void
+    [PreviewEmoteEventType.ANIMATION_PAUSE]: void
+    [PreviewEmoteEventType.ANIMATION_LOOP]: void
+    [PreviewEmoteEventType.ANIMATION_END]: void
+    [PreviewEmoteEventType.ANIMATION_PLAYING]: { length: number }
   }
 
-  const events = new EventEmitter<Events>()
+  const events = mitt<Events>()
 
   // Emit the PreviewEmoteEventType.ANIMATION_PLAYING event with the current playing frame
   const emitPlayingEvent = () => {

--- a/src/lib/babylon/emote.ts
+++ b/src/lib/babylon/emote.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events'
+import EventEmitter from '@foxify/events'
 import {
   AnimationGroup,
   ArcRotateCamera,
@@ -22,7 +22,14 @@ import { startAutoRotateBehavior } from './camera'
 import { Asset, loadAssetContainer, loadSound } from './scene'
 import { getEmoteRepresentation } from '../representation'
 
-const loopedEmotes = [PreviewEmote.IDLE, PreviewEmote.MONEY, PreviewEmote.CLAP, PreviewEmote.WALK, PreviewEmote.RUN, PreviewEmote.JUMP]
+const loopedEmotes = [
+  PreviewEmote.IDLE,
+  PreviewEmote.MONEY,
+  PreviewEmote.CLAP,
+  PreviewEmote.WALK,
+  PreviewEmote.RUN,
+  PreviewEmote.JUMP,
+]
 
 let intervalId: number | undefined
 
@@ -64,7 +71,11 @@ export function loadEmoteSound(scene: Scene, emote: EmoteDefinition, config: Pre
   return loadSound(scene, representation)
 }
 
-export async function playEmote(scene: Scene, assets: Asset[], config: PreviewConfig) {
+export async function playEmote(
+  scene: Scene,
+  assets: Asset[],
+  config: PreviewConfig
+): Promise<IEmoteController | undefined> {
   // load asset container for emote
   let container: AssetContainer | undefined
   let loop = !!config.emote && isLooped(config.emote)
@@ -234,7 +245,16 @@ function createController(animationGroup: AnimationGroup, loop: boolean, sound: 
     Engine.audioEngine.setGlobalVolume(0)
   }
 
-  const events = new EventEmitter()
+  // Temporary typed events.
+  type Events = {
+    [PreviewEmoteEventType.ANIMATION_PLAY]: () => unknown
+    [PreviewEmoteEventType.ANIMATION_PAUSE]: () => unknown
+    [PreviewEmoteEventType.ANIMATION_LOOP]: () => unknown
+    [PreviewEmoteEventType.ANIMATION_END]: () => unknown
+    [PreviewEmoteEventType.ANIMATION_PLAYING]: ({ length }: { length: number }) => unknown
+  }
+
+  const events = new EventEmitter<Events>()
 
   // Emit the PreviewEmoteEventType.ANIMATION_PLAYING event with the current playing frame
   const emitPlayingEvent = () => {


### PR DESCRIPTION
This PR changes the `EventEmitter` class, that comes from the node std for a library built to work in both browser and node environments. The new library includes type checking for the events and the handlers as well.