### PR TITLE
fix: third-party wearable rendering

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -37,11 +37,12 @@ import { computeZoom, getZoom } from './zoom'
 
 const DEFAULT_PROFILE = 'default'
 const QUANTITY_OF_PARTS_ON_SHORTENED_ITEMS_URN = 6
+const THIRD_PARTY_URN_ID = "collections-thirdparty"
 
 function getTokenIdAndAssetUrn(completeUrn: string): { assetUrn: string; tokenId: string | undefined } {
   const lastIndex = completeUrn.lastIndexOf(':')
 
-  return lastIndex !== -1 && completeUrn.split(':').length > QUANTITY_OF_PARTS_ON_SHORTENED_ITEMS_URN
+  return lastIndex !== -1 && completeUrn.split(':').length > QUANTITY_OF_PARTS_ON_SHORTENED_ITEMS_URN && !completeUrn.includes(THIRD_PARTY_URN_ID)
     ? { assetUrn: completeUrn.substring(0, lastIndex), tokenId: completeUrn.substring(lastIndex + 1) }
     : { assetUrn: completeUrn, tokenId: undefined }
 }


### PR DESCRIPTION
This PR addresses how third-party wearables are processed. When an extended URN is received (i.e., urn.Split(':').Length > 6), it cuts off the last part and returns the shortened version. This is necessary because the /entities/active endpoint from Catalysts' content servers expects the shortened URN to return the wearable/emote metadata.

The issue was that wearables from third-party providers contain 7 parts, causing the code to mistakenly treat them as extended URNs, which is not the case. Third-party wearables have an additional part but that part do not represent a token id (which is the part that should be removed), so we need to call the Catalysts endpoint using the entire URN received instead of shortening it.

The changes in this PR prevent the removal of the last part of the URN when this method receives a wearable's URN from a third-party provider (i.e., urn.Contains("collections-thirdparty")).