### PR TITLE
fix: Allow new third parties URN

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -133,11 +133,9 @@ async function fetchURNs(urns: string[], peerUrl: string): Promise<[WearableDefi
     return [[], []]
   }
 
-  console.log('All URNs', urns)
   const sanitizedAssetUrns = urns
     .map((urn: string) => urn.replace(/^dcl:\/\/base-avatars\//, 'urn:decentraland:off-chain:base-avatars:'))
     .map((urn: string) => getTokenIdAndAssetUrn(urn).assetUrn)
-  console.log('Sanitized asset urns', sanitizedAssetUrns)
 
   return peerApi.fetchItems(sanitizedAssetUrns, peerUrl)
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -63,7 +63,10 @@ function getTokenIdAndAssetUrn(completeUrn: string): URNData {
       contractAddress: urnProperties[8],
       network: urnProperties[7],
     }
-  } else if (urnPropertiesLength > QUANTITY_OF_PARTS_ON_SHORTENED_ITEMS_URN) {
+  } else if (
+    !completeUrn.includes(THIRD_PARTY_URN_ID) &&
+    urnPropertiesLength > QUANTITY_OF_PARTS_ON_SHORTENED_ITEMS_URN
+  ) {
     result = { assetUrn: urnProperties.slice(0, -1).join(':'), tokenId: urnProperties[urnProperties.length - 1] }
   }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -37,14 +37,37 @@ import { computeZoom, getZoom } from './zoom'
 
 const DEFAULT_PROFILE = 'default'
 const QUANTITY_OF_PARTS_ON_SHORTENED_ITEMS_URN = 6
-const THIRD_PARTY_URN_ID = "collections-thirdparty"
+const THIRD_PARTY_URN_ID = 'collections-thirdparty'
+const MAPPED_THIRD_PARTY_ITEM_FULL_URN_PROPERTIES_LENGTH = 10
 
-function getTokenIdAndAssetUrn(completeUrn: string): { assetUrn: string; tokenId: string | undefined } {
-  const lastIndex = completeUrn.lastIndexOf(':')
+type URNData = {
+  assetUrn: string
+  tokenId?: string
+  network?: string
+  contractAddress?: string
+}
 
-  return lastIndex !== -1 && completeUrn.split(':').length > QUANTITY_OF_PARTS_ON_SHORTENED_ITEMS_URN && !completeUrn.includes(THIRD_PARTY_URN_ID)
-    ? { assetUrn: completeUrn.substring(0, lastIndex), tokenId: completeUrn.substring(lastIndex + 1) }
-    : { assetUrn: completeUrn, tokenId: undefined }
+function getTokenIdAndAssetUrn(completeUrn: string): URNData {
+  const urnProperties = completeUrn.split(':')
+  const urnPropertiesLength = urnProperties.length
+
+  let result: URNData | undefined
+
+  if (
+    completeUrn.includes(THIRD_PARTY_URN_ID) &&
+    urnPropertiesLength === MAPPED_THIRD_PARTY_ITEM_FULL_URN_PROPERTIES_LENGTH
+  ) {
+    result = {
+      assetUrn: urnProperties.slice(0, 7).join(':'),
+      tokenId: urnProperties[9],
+      contractAddress: urnProperties[8],
+      network: urnProperties[7],
+    }
+  } else if (urnPropertiesLength > QUANTITY_OF_PARTS_ON_SHORTENED_ITEMS_URN) {
+    result = { assetUrn: urnProperties.slice(0, -1).join(':'), tokenId: urnProperties[urnProperties.length - 1] }
+  }
+
+  return result ?? { assetUrn: completeUrn, tokenId: undefined }
 }
 
 async function fetchItem(urn: string, peerUrl: string) {
@@ -110,9 +133,11 @@ async function fetchURNs(urns: string[], peerUrl: string): Promise<[WearableDefi
     return [[], []]
   }
 
+  console.log('All URNs', urns)
   const sanitizedAssetUrns = urns
     .map((urn: string) => urn.replace(/^dcl:\/\/base-avatars\//, 'urn:decentraland:off-chain:base-avatars:'))
     .map((urn: string) => getTokenIdAndAssetUrn(urn).assetUrn)
+  console.log('Sanitized asset urns', sanitizedAssetUrns)
 
   return peerApi.fetchItems(sanitizedAssetUrns, peerUrl)
 }


### PR DESCRIPTION
This PR makes it possible for the site to process the new wearables' third party URNs.
The URN in the user's profile is represented as:
`urn:decentraland:amoy:collections-thirdparty:back-to-the-future:amoy-eb54:tuxedo-6751:amoy:0x1d9fb685c257e74f869ba302e260c0b68f5ebb37:15`
And we need to remove the network, contract and token id parts to get a valid pointer.