### PR TITLE
feat: enable to pass an entity as profile

### DIFF
--- a/src/lib/api/peer.ts
+++ b/src/lib/api/peer.ts
@@ -124,6 +124,20 @@ class PeerApi {
       return null
     }
   }
+
+  async fetchProfileEntity(content: string, peerUrl: string) {
+    try {
+      const entity = await json<Entity>(`${peerUrl}/content/contents/${content}`)
+      if (entity.type !== 'profile') {
+        throw new Error('The content is not a profile')
+      }
+
+      return entity.metadata as Profile
+    } catch (error) {
+      console.error('There was an error loading the profile', error)
+      return null
+    }
+  }
 }
 
 export const peerApi = new PeerApi()


### PR DESCRIPTION
You now can pass an entity as profile (it validates that the entity's type is `profile`)

![image](https://github.com/user-attachments/assets/11d2ddd6-31f0-4c51-bbea-0c7ef8d3f0b0)
