### PR TITLE
Add GetElementBounds iframe API for E2E testing

### DIFF
--- a/src/lib/unity/messages.ts
+++ b/src/lib/unity/messages.ts
@@ -21,6 +21,9 @@ export enum UnityMethod {
   // Control methods
   RELOAD = 'Reload',
   CLEANUP = 'Cleanup',
+
+  // Query methods
+  GET_ELEMENT_BOUNDS = 'GetElementBounds',
 }
 
 // Property mapping to Unity JSBridge methods


### PR DESCRIPTION
## Summary
- Adds `GetElementBounds` to the `UnityMethod` enum in `messages.ts`
- Handles incoming `get_element_bounds` postMessage requests from the parent window, forwarding them to Unity via `SendMessage('JSBridge', 'GetElementBounds', elementName)`
- Relays Unity's `element-bounds` response back to the parent as `element_bounds_response`

This enables E2E tests (and any parent webapp) to query UIToolkit element positions inside the Unity canvas through the existing iframe postMessage API, without needing direct access to the Unity instance.

### Message flow
```
Parent  →  postMessage({ type: 'get_element_bounds', payload: { elementName } })  →  iframe
iframe  →  SendMessage('JSBridge', 'GetElementBounds', elementName)               →  Unity
Unity   →  postMessage({ type: 'unity-renderer', payload: { type: 'element-bounds', ... } })  →  iframe
iframe  →  postMessage({ type: 'element_bounds_response', payload })              →  Parent
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)