### PR TITLE
fix: Apply package.json fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/decentraland/wearable-preview.git"
+    "url": "git+https://github.com/decentraland/wearable-preview.git"
   },
   "prettier": {
     "semi": false,

--- a/public/package.json
+++ b/public/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/decentraland/wearable-preview.git"
+    "url": "git+https://github.com/decentraland/wearable-preview.git"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary

This pull request makes a minor update to the `package.json` file, changing the repository URL to use the `git+https` protocol. This is a small metadata improvement that helps with certain package managers and tooling.

<img width="1071" height="89" alt="image" src="https://github.com/user-attachments/assets/c1ebf976-4335-4de4-b40f-e7b924ce6a58" />
