### PR TITLE
fix: prevent unmovable scrollbar in preview viewport

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,11 @@
+html,
+body {
+  /* The preview is a full-viewport viewer: the canvas is sized to window.innerWidth/innerHeight
+     (which include the scrollbar gutter), so allowing scroll creates a feedback loop where a
+     scrollbar shrinks the content area below the canvas size, perpetuating the overflow. */
+  overflow: hidden;
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',


### PR DESCRIPTION
The preview canvas is sized with `window.innerWidth`/`window.innerHeight`, which include the scrollbar gutter, while the actual content area (`documentElement.clientWidth`) excludes it. Because neither `html`/`body` nor `.Preview` set `overflow: hidden`, any trigger that introduces a scrollbar — sub-pixel rounding on fractional device pixel ratios, a window/iframe resize, or a host iframe that already has its own scrollbar — shrinks the content area by ~17px while the canvas stays at the full viewport width. The canvas then overflows by the scrollbar width, which keeps the scrollbar alive in a self-perpetuating loop.

The result is a scrollbar that appears but cannot be moved: the rendered avatar fits entirely, and only the full-size canvas overhangs by the scrollbar width. This is why it only showed up in some embeddings (depending on DPR or the host's own scrollbar).

Fix: set `overflow: hidden` on `html, body`. The preview is a full-viewport viewer whose document should never scroll, so hiding overflow breaks the feedback loop at its source and applies to both the Babylon and Unity previews.

Verified by reproducing the overflow (17x16px after a resize), isolating the cause with canvas-size / overflow experiments, and confirming overflow stays at 0 across multiple viewport sizes after the change. `build` (typecheck) passes.
