### PR TITLE
fix: prevent stale renders and hung screenshot RPCs in embedded previews

### DIFF
--- a/src/components/Preview/Preview.tsx
+++ b/src/components/Preview/Preview.tsx
@@ -41,6 +41,10 @@ const Preview: React.FC = () => {
 
   useEffect(() => {
     let removeEmoteEvents: () => unknown = () => {}
+    // when the config changes while a render is still in flight, the in-flight render is stale: its
+    // results must be discarded so the parent window never gets a LOAD (and takes screenshots) for a
+    // scene that is about to be replaced
+    let isStale = false
     if (canvasRef.current && config) {
       let style: React.CSSProperties = { opacity: 1 } // fade in effect
 
@@ -65,16 +69,19 @@ const Preview: React.FC = () => {
         // preview models
         render(canvasRef.current, config)
           .then((newController) => {
+            if (isStale) return
             // set new controller as current one
             controller.current = newController
             // handle emote events and forward them as messages
             removeEmoteEvents = handleEmoteEvents(controller.current)
           })
           .catch((error) => {
+            if (isStale) return
             captureException(error, { component: 'Preview', phase: 'render' })
             setPreviewError(error.message)
           })
           .finally(() => {
+            if (isStale) return
             setIsLoadingModel(false)
             setIsLoaded(true)
           })
@@ -82,18 +89,28 @@ const Preview: React.FC = () => {
     }
 
     return () => {
+      isStale = true
       removeEmoteEvents()
     }
   }, [canvasRef.current, config]) // eslint-disable-line
 
   // send a mesasge to the parent window when loaded or error occurs
   useEffect(() => {
-    if (!isMessageSent) {
+    // if a newer config is already loading (e.g. an update arrived via postMessage while the first
+    // render was in flight), don't announce this render: it's stale and about to be replaced. The
+    // upcoming render will send its own LOAD. This prevents embedders from taking screenshots of
+    // an outdated scene.
+    if (!isMessageSent && !isLoadingConfig) {
       if (isLoaded) {
         sendMessage(getParent(), PreviewMessageType.LOAD, { renderer: PreviewRenderer.BABYLON })
         setIsMessageSent(true)
         if (config?.type === PreviewType.AVATAR || (config?.emote && config.emote !== PreviewEmote.IDLE)) {
-          controller.current?.emote.play()
+          try {
+            controller.current?.emote.play()
+          } catch (error) {
+            // the emote controller can be the invalid stub (e.g. the emote failed to load), keep the preview alive
+            console.warn('Could not play emote', error)
+          }
         }
       } else if (error) {
         captureException(new Error(error), { component: 'Preview', phase: 'sendErrorToParent' })
@@ -101,7 +118,7 @@ const Preview: React.FC = () => {
         setIsMessageSent(true)
       }
     }
-  }, [isLoaded, error, isMessageSent, controller, config?.type, config?.emote])
+  }, [isLoaded, error, isMessageSent, isLoadingConfig, controller, config?.type, config?.emote])
 
   // when the config is being loaded again (because the was an update to some of the options) reset all the other loading flags
   useEffect(() => {

--- a/src/lib/scene.ts
+++ b/src/lib/scene.ts
@@ -12,7 +12,16 @@ const ignoreTextureList = [
 ]
 
 export function createSceneController(engine: Engine, scene: Scene, camera: ArcRotateCamera): ISceneController {
+  function checkNotDisposed() {
+    // this controller can outlive its scene: re-rendering (e.g. after an options update) disposes the engine and creates a new controller.
+    // Babylon hangs forever on a disposed engine, so fail fast and let the caller retry against the new controller instead.
+    if (!engine.getRenderingCanvas() || scene.isDisposed) {
+      throw new Error('The scene was disposed, a newer render has replaced it')
+    }
+  }
+
   async function getScreenshot(width: number, height: number) {
+    checkNotDisposed()
     return Tools.CreateScreenshotUsingRenderTargetAsync(engine, camera, { width, height }, undefined, undefined, true)
   }
 
@@ -41,6 +50,7 @@ export function createSceneController(engine: Engine, scene: Scene, camera: ArcR
   }
 
   async function getMetrics() {
+    checkNotDisposed()
     const triangles = scene.meshes
       .filter((mesh) => !mesh.name.toLowerCase().includes('collider')) // remove colliders from metrics
       .reduce((total, mesh) => {


### PR DESCRIPTION
## Problem

When the preview is embedded via iframe (e.g. the Builder's hidden thumbnail-capture preview), the item blob arrives through `postMessage` **after** the iframe's first render. The intermediate (item-less) render and the final render race each other, which caused three real failures observed while auto-generating wearable thumbnails in the Builder:

1. **Embedders screenshot an outdated scene.** A superseded in-flight render still installed its controller and emitted a `LOAD` message, so the embedder's `onLoad` handler could capture the pre-update scene.
2. **Screenshot/metrics RPCs hang forever.** `createScene` disposes the previous engine on re-render, and Babylon's `CreateScreenshotUsingRenderTargetAsync` on a disposed engine logs `No rendering canvas found!` and never resolves — surfacing as `Request timeout for getScreenshot` / `getMetrics` in the embedder.
3. **A failed emote crashes the preview.** `emote.play()` on the invalid emote controller stub threw `InvalidEmoteError` inside a React effect, unmounting the whole tree and leaving the embedder stuck on an eternal loading state.

## Changes

- `Preview.tsx`: the render effect discards the results of an in-flight render once its config has been replaced (no stale controller, no stale `LOAD`), and `LOAD` is not announced while a newer config is still loading — the upcoming render announces its own.
- `scene.ts`: `getScreenshot` and `getMetrics` fail fast with a clear error when their scene/engine has been disposed, so RPC callers get an immediate rejection instead of a 30s timeout and can retry against the current controller.
- `Preview.tsx`: `emote.play()` failures are logged without crashing the preview, matching the existing intent in `render.ts` ("let the rest of the preview keep working").

## Testing

Reproduced the Builder embed flow with a harness page (iframe + `ready`/`update`/`load` postMessage sequence + `getScreenshot` controller RPC, including Builder's hidden 0-height container): before the fix the first-load screenshot raced the second render (hangs/stale captures); after the fix captures are deterministic. Verified no regressions on standalone previews (`?profile=default` avatar idle, single-wearable `?contract=…&item=…`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)