### PR TITLE
fix: forward the requested preview type to the unity renderer

### DIFF
--- a/src/hooks/useUnityConfig.ts
+++ b/src/hooks/useUnityConfig.ts
@@ -67,9 +67,16 @@ type QueryParams = {
   camera: PreviewCamera
   projection: PreviewProjection
   emote: string
+  type: string
   urn: string[]
   base64: string[]
 }
+
+// Only these two express a view the renderer can be pinned to: the item on its own or the item
+// worn by an avatar. TEXTURE is not a view, it's resolved below from the item's representation and
+// only tells the JS side to show the thumbnail instead of the canvas.
+const getRequestedType = (type: PreviewType | null | undefined): PreviewType | null =>
+  type === PreviewType.AVATAR || type === PreviewType.WEARABLE ? type : null
 
 const getDefaultColors = (
   profile: Avatar | null,
@@ -146,7 +153,10 @@ export function useUnityConfig(): [UnityPreviewConfig | null, boolean, string | 
           options.marketplaceServerUrl || options.nftServerUrl || config.get('MARKETPLACE_SERVER_URL')
 
         // Initialize basic config
-        let type = PreviewType.WEARABLE
+        // A caller that asked for a specific view gets it; when nobody asked we keep defaulting to
+        // the item view, and the renderer decides (see PreviewController) which view to open in.
+        const requestedType = getRequestedType(options.type)
+        let type = requestedType || PreviewType.WEARABLE
         let background: Background = {
           color: options.background || '#4b4852',
           transparent: options.disableBackground === true,
@@ -189,7 +199,9 @@ export function useUnityConfig(): [UnityPreviewConfig | null, boolean, string | 
               image: item.thumbnail,
             }
             const representation = getWearableRepresentationOrDefault(item)
-            if (isTexture(representation)) {
+            // An avatar can wear a texture-only wearable, so an explicit avatar request wins over
+            // the texture fallback (same precedence as the Babylon path, see lib/config.ts).
+            if (isTexture(representation) && type !== PreviewType.AVATAR) {
               type = PreviewType.TEXTURE
             }
           }
@@ -273,6 +285,11 @@ export function useUnityConfig(): [UnityPreviewConfig | null, boolean, string | 
                 camera,
                 projection,
                 emote: toQueryValue(emote?.toString() || ''),
+                // Unity reads its config from this URL, so the requested view has to travel here to
+                // reach it. We forward the caller's request and not the resolved `type`: an empty
+                // value means "no preference", which is what lets the renderer fall back to the
+                // view the user last picked.
+                type: toQueryValue(requestedType),
                 urn: urns.length > 0 ? urns : [''],
                 base64: base64s.length > 0 ? base64s : [''],
               }

--- a/src/lib/unity/messages.ts
+++ b/src/lib/unity/messages.ts
@@ -19,6 +19,7 @@ export enum UnityMethod {
   SET_ITEM_ID = 'SetItemID',
   SET_TOKEN_ID = 'SetTokenID',
   SET_DISABLE_LOADER = 'SetDisableLoader',
+  SET_TYPE = 'SetType',
 
   // Control methods
   RELOAD = 'Reload',
@@ -49,6 +50,7 @@ const PROPERTY_METHOD_MAP: Record<string, UnityMethod> = {
   itemId: UnityMethod.SET_ITEM_ID,
   tokenId: UnityMethod.SET_TOKEN_ID,
   disableLoader: UnityMethod.SET_DISABLE_LOADER,
+  type: UnityMethod.SET_TYPE,
 }
 
 // Individual method handlers for specific value transformations
@@ -69,6 +71,7 @@ const VALUE_TRANSFORMERS: Record<string, (value: any) => string> = {
   itemId: (value) => String(value),
   tokenId: (value) => String(value),
   disableLoader: (value) => String(value),
+  type: (value) => String(value),
 }
 
 export const sendUnityMessage = (unityInstance: any, method: UnityMethod | string, value?: any) => {


### PR DESCRIPTION
`type` never reaches the Unity renderer, so a caller that asks for the avatar view does not get it.

## What happens today

A caller passes `type={PreviewType.AVATAR}`. On the **Babylon** path that is honoured (`src/lib/config.ts` consults `options.type`). On the **Unity** path it is dropped:

- `src/hooks/useUnityConfig.ts` starts from `let type = PreviewType.WEARABLE` and **never reads `options.type`** — it only ever flips it to `TEXTURE`.
- The resolved `type` was never forwarded in `updateQueryParams`, and Unity reads its config from that URL via `Application.absoluteURL`. So even a correct value had no transport.

Downstream, aang then decides the view from `PlayerPrefs`, which in WebGL is per-origin IndexedDB — so whatever a user last clicked sticks, across sessions and across every app sharing the preview origin. Net effect for consumers: an explicitly requested avatar view opens on the item-alone view instead, seemingly at random.

Found while fixing Decentraland's Shop fitting room, which asks for the avatar view and got the item view. It had to move to Babylon to work around this.

## The change

- `getRequestedType()` accepts only `AVATAR`/`WEARABLE`. `TEXTURE` is deliberately excluded — it is not a view but a signal to the JS side to draw the thumbnail instead of the canvas.
- The texture fallback is gated on `type !== AVATAR`, mirroring the precedence the Babylon path already has.
- `type` is forwarded in `updateQueryParams`.
- `SET_TYPE` added to `src/lib/unity/messages.ts` with its `PROPERTY_METHOD_MAP` and `VALUE_TRANSFORMERS` entries. Runtime overrides arrive by `postMessage` and never touch the URL, so without this a `type` override was logged as "No Unity method mapping found" and silently dropped.

## Two deliberate decisions worth reviewing

**It forwards `requestedType`, not the resolved `type`.** Forwarding the resolved value would put `type=wearable` on every call and permanently kill aang's PlayerPrefs fallback. An empty value means "no preference", which is what lets the renderer fall back correctly.

**No `urns.length > 0 → AVATAR` inference**, unlike the Babylon path. On the Unity path `mode` already decides the shape of the scene, and inferring AVATAR from a urn would flip every existing marketplace item page — single urn — from the item view to the avatar view. Only an explicit request pins the view.

## Companion change

This half only carries the value; the renderer must also read it. decentraland/aang-renderer has the matching PR, which adds the `type` parameter, makes it win over `PlayerPrefs`, and fixes a separate bug where marketplace mode silently previewed only the first of several urns. **Neither is useful alone.**

## Verification

`npx tsc -b` reports no errors in either touched file. The repo has ~16 pre-existing errors from a stale `node_modules` (missing `@sentry/browser`; `@dcl/schemas` missing `SpringBoneParams`/`IPhysicsController`) — all unrelated. There are no test files in this repo, so there was no suite to extend; CI runs `npm run build`.

Not done: threading `disableSwitcher` (added on the aang side) through this package. `options` is typed `PreviewOptions` from `@dcl/schemas`, which has no such field, so doing it properly needs a schemas change first. In the meantime an unknown `disableSwitcher=true` already survives to `Application.absoluteURL` untouched, because `updateQueryParams` only deletes keys it writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01939G3Nga5vvpb8v4T74EJD
