### PR TITLE
fix: prevent the host page from scrolling while wheel-zooming the preview

### DIFF
--- a/src/lib/babylon/scene.ts
+++ b/src/lib/babylon/scene.ts
@@ -210,6 +210,14 @@ export async function createScene(
     camera.upperRadiusLimit = camera.radius
   }
 
+  // The wheel zooms the camera, but the browser also scrolls: since this document never scrolls
+  // (overflow is hidden) the scroll chains to the embedding page. Cancel it while zooming is possible.
+  if (config.camera === PreviewCamera.INTERACTIVE && camera.upperRadiusLimit !== camera.lowerRadiusLimit) {
+    const preventScroll = (event: WheelEvent) => event.preventDefault()
+    canvas.addEventListener('wheel', preventScroll, { passive: false })
+    root.onDisposeObservable.addOnce(() => canvas.removeEventListener('wheel', preventScroll))
+  }
+
   // Setup lights
   if (config.type === PreviewType.WEARABLE) {
     const directional = new DirectionalLight('directional', new Vector3(0, 0, 1), root)


### PR DESCRIPTION
## Problem

Using the mouse wheel over the embedded Babylon preview (e.g. an emote item detail page in the marketplace) zooms the camera **and** scrolls the page underneath it.

Repro with the dev server: `?profile=default&wheelZoom=2&wheelPrecision=50&wheelStart=50` inside an iframe on a tall page → wheel over the preview zooms and the host page scrolls at the same time.

## Cause

In `createScene` (`src/lib/babylon/scene.ts`) the camera is attached with `camera.attachControl(canvas, true)`. That second argument is Babylon's `noPreventDefault`, so `ArcRotateCameraMouseWheelInput` applies the zoom but never calls `preventDefault()` on the wheel event. The preview document has `overflow: hidden` (from #190), so it cannot consume the scroll itself and the browser chains it out to the embedding page.

## Fix

Cancel the wheel event on the canvas with an explicit non-passive listener, removed when the scene is disposed. It is attached only when the camera is interactive and the radius limits actually allow zooming, so static or zoom-locked embeds keep scrolling the host page as before.

Two notes on the seam:

- Flipping `attachControl`'s `noPreventDefault` to `false` would also make Babylon `preventDefault()` on pointer events, and the scene deliberately sets `preventDefaultOnPointerDown = false` — an explicit wheel listener leaves drag behaviour untouched.
- A React `onWheel` handler would not work: React registers `wheel` as a passive listener, so `preventDefault()` there is ignored.

## Tests

No automated tests — the repo has no test suite (`npx jest` finds 0 matches). Verified manually in Chrome against the local dev build:

- wheel dispatched on the canvas is cancelled (`dispatchEvent` returns `false`); the same event on `body` is not;
- repeated wheel events still change the camera radius, so zoom keeps working;
- with `camera=static`, the wheel event is not cancelled, so non-interactive embeds still scroll normally.

Real trusted wheel events could not be driven end-to-end through the automation tool (its scroll action scrolls the page directly without emitting wheel events), so verification was done at the event level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)