### PR TITLE
fix: align Babylon wearable shading with the Unity renderer

### DIFF
--- a/docs/ai-agent-context.md
+++ b/docs/ai-agent-context.md
@@ -29,9 +29,10 @@ The Wearable Preview is a webapp that renders interactive 3D previews of Decentr
 - Framework: React 18
 - Build Tool: Vite
 - Language: TypeScript
-- 3D Rendering: Babylon.js 8.x (primary), Unity WebGL (alternative renderer)
+- 3D Rendering: Babylon.js 4.2 (primary), Unity WebGL (alternative renderer)
 - UI: decentraland-ui
 - Schemas: @dcl/schemas for type definitions and message types
+- Tests: Vitest (`npm test`)
 
 **External Dependencies:**
 

--- a/docs/emissive-tonemapping-parity.md
+++ b/docs/emissive-tonemapping-parity.md
@@ -138,11 +138,32 @@ material, which should not have moved at all:
 | **ACES, exposure 2 (shipped)** | **`#F9D2AF`** | **`#6D150F`** |
 | ACES, exposure 3 | `#FADFC3` | `#7D1913` |
 
-Exposure 1 would have traded the emissive bug for a darker catalogue. 2.0 is the
-conventional compensation for ACES over LDR-authored content and lands the non-emissive
-material within a few units of Unity. 3.0 fits *this item's* feathers better but is a larger
-lift than has been validated against skin and facial features, so it is not the default.
-`?exposure=` overrides it for QA sweeps.
+Exposure 1 would have traded the emissive bug for a darker catalogue, so the default started
+at 2.0 — the conventional compensation for ACES over LDR-authored content — chosen from this
+one wearable because the avatar could not be rendered locally at the time.
+
+**Re-measured across the catalogue, 2.0 was too bright.** Overriding `?peerUrl=` and
+`?marketplaceServerUrl=` to the `.org` endpoints makes the avatar render on the local dev
+server (the "blank avatar" below was the dev config pointing at `.zone`), which allowed a
+sweep against the Unity renderer over 10 marketplace wearables. Mean avatar luminance,
+signed, against Unity's 120.0/255:
+
+| exposure | luminance vs Unity | mean abs. error | per-pixel Δ |
+| - | - | - | - |
+| `toneMapping=none` (master) | +9.6 | 19.1 | 46.4 |
+| 1.0 | −11.4 | 11.6 | 40.6 |
+| 1.15 | −4.8 | 8.5 | 39.4 |
+| **1.2 (shipped)** | **−2.8** | **8.7** | **39.6** |
+| 1.3 | +0.9 | 10.0 | 40.1 |
+| 2.0 | +20.3 | 23.6 | 49.6 |
+
+At 2.0 the tonemapping made most of the catalogue *further* from Unity than master was — it
+fixed emissive wearables and washed out everything else. The optimum is a flat basin from
+1.1 to 1.3 on both metrics; 1.2 sits in it with less dark bias than 1.15. `?exposure=`
+overrides it for QA sweeps.
+
+Note this trades a little fidelity on the reference wearable's feathers (which favoured a
+*higher* lift) for the rest of the catalogue, since emissive-heavy items are the minority.
 
 ### Step 3 — Keep the GlowLayer from compounding
 
@@ -220,12 +241,20 @@ remains deferred as planned.
   material, before alpha blending (constraint 5). Stacked transparent emissive surfaces —
   exactly this wearable — will stay close but never identical.
 
-**V4 could not be validated locally.** The Babylon avatar renders blank on the local dev
-server, including with `?toneMapping=none`, so the failure is environmental and predates this
-change — but it means skin, hair and facial features have *not* been checked against the
-tonemapping. That is the highest-risk case (constraint 3) and the reason the exposure default
-is the conservative 2.0 rather than the better-fitting 3.0. **Run V4 in a working environment
-before merging**, and re-evaluate the exposure default there.
+**The local "blank avatar" was a dev-config issue, now worked around.** `src/config/env/dev.json`
+points `PEER_URL` at `peer.decentraland.zone`, where mainnet marketplace wearables do not
+exist. Passing `?peerUrl=https://peer.decentraland.org` and
+`?marketplaceServerUrl=https://marketplace-api.decentraland.org` renders the avatar fine, which
+is how the exposure sweep above was run — so skin, hair and facial features have now been
+checked against the tonemapping across 38 wearables.
+
+Two unrelated gotchas found while building that harness, both worth fixing separately:
+
+- Unity ignores `?urn=` and silently falls back to a bare default avatar. Use `?contract=` +
+  `?item=`, and note Unity only equips the item when a `?mode=` is set (`marketplace` works;
+  `builder`, `profile` and `authentication` do not).
+- `?profile=default` picks a random one of 159 default outfits per load, so any before/after
+  screenshot comparison needs a pinned `default<N>`.
 
 ## Test cases
 

--- a/docs/emissive-tonemapping-parity.md
+++ b/docs/emissive-tonemapping-parity.md
@@ -1,0 +1,287 @@
+# Babylon ↔ Unity emissive / tonemapping parity
+
+Branch: `fix/emissive-tonemapping-unity-parity`
+
+## Problem
+
+Wearables with a non-zero `emissiveFactor` render very differently in the Babylon
+preview than in the Unity preview (`?unity=true`), which is the reference look.
+
+Reproduced with `Hell's Angels`
+(`0x65ed61c4fc2d1102ed574a48e664b90b7a300ea8` item `0`,
+content hash `QmSqtxt7bfbhm8W5bNVisrd2rpbSsG7X3bsWrRCUEQXh2G`). Its two materials
+isolate the cause:
+
+| material           | baseColorTexture         | alphaMode | emissiveFactor              | Unity vs Babylon |
+| ------------------ | ------------------------ | --------- | --------------------------- | ---------------- |
+| `Material.001`     | `Fire2.jpg` (orange)     | `BLEND`   | `[0.4812, 0, 0.0036]`       | **diverges**     |
+| `Material.002`     | black→red gradient       | `OPAQUE`  | `[0, 0, 0]`                 | matches          |
+
+Only the emissive material diverges. Sampled pixels: Unity feathers `#FDFBD2`
+(flat pale cream, fire texture invisible), Babylon `#E04020` (saturated fire red).
+
+## Cause
+
+**Unity (`aang-renderer`) multiplies `emissiveFactor` by 12.5 and tonemaps the result.**
+
+- `Assets/Scripts/Loading/ToonMaterialGenerator.cs:12,55` —
+  `_Emissive_Color = gltfMaterial.Emissive * EMISSIVE_MAGIC_NUMBER`, `EMISSIVE_MAGIC_NUMBER = 5f`.
+- `DCL_ToonBodyDoubleShadeWithFeather.hlsl:382` —
+  `emissive = _Emissive_Tex_var.rgb * _Emissive_Color.rgb * 2.5f`. There is no emissive
+  texture on this material and `_Emissive_Tex` defaults to `"white"` (`DCL_Toon.shader:158`),
+  so it passes through at 1.0.
+- Net **×12.5**: `0.4812 → 6.02` linear red, well into HDR
+  (`URP_Asset.asset`: `m_SupportsHDR: 1`, `m_ColorGradingMode: 1`).
+- `URP_GlobalVolumeProfile.asset` then applies **ACES** tonemapping (`Tonemapping.mode: 2`)
+  plus Bloom (threshold 1, intensity 1, scatter 0.6).
+
+ACES walks a very bright saturated red up the red→orange→yellow→white path and
+desaturates it. At 6.0 linear the base texture's own contribution (≤0.3 linear) is
+swamped, which is why the Unity feathers are flat cream with zero fire detail while
+the non-emissive inner gradient renders normally.
+
+**Babylon (`wearable-preview`) applies `emissiveFactor` 1:1 with no tonemapping.**
+
+- `src/lib/babylon/wearable.ts:39-48` only zeroes metallic/specular; emissive is untouched,
+  so `emissiveColor` stays at the raw glTF value (verified at runtime: `[0.4812, 0, 0.0036]`).
+- Nothing in `src/` ever sets `toneMappingEnabled`, so Babylon's default (off) applies and
+  the LDR result simply clamps.
+- `src/lib/babylon/scene.ts:235-238` adds a `GlowLayer` at `intensity = 2.0`, which latches
+  onto that red emissive and pushes the saturated red further still.
+
+Verified by loading the same GLB into a bare Babylon scene twice: with the current
+`wearable-preview` setup, and with only two changes (emissive ×12.5, ACES enabled). The
+second reproduces the Unity look.
+
+## Constraints discovered while scoping
+
+These shape the design and are the reason the plan is staged rather than one commit.
+
+1. **Screenshots bypass camera post-processes.** `src/lib/scene.ts:23-26` uses
+   `Tools.CreateScreenshotUsingRenderTargetAsync`, which renders into a fresh
+   `RenderTargetTexture` (`node_modules/@babylonjs/core/Misc/screenshotTools.js:132-143`).
+   The camera's post-process chain is *not* applied — only an explicitly added FXAA pass is.
+   So tonemapping added via `DefaultRenderingPipeline` would show on the live canvas but
+   **not** in the screenshots the shop/marketplace consume. Tonemapping via
+   `scene.imageProcessingConfiguration` is applied *inside* the material shaders
+   (`pbr.fragment`, `default.fragment` both include `imageProcessingFunctions`) and therefore
+   does survive the RTT path.
+
+2. **`getMetrics()` counts scene textures against a hardcoded ignore list**
+   (`src/lib/scene.ts:5-12`). Any new rendering pipeline adds RTTs and would inflate the
+   reported texture count that the Builder validates against.
+
+3. **Facial features render entirely through the emissive channel.**
+   `src/lib/babylon/face.ts:74-86` builds a `StandardMaterial` with `diffuseColor = Black()`
+   and `emissiveTexture = mask`. `StandardMaterial` also applies scene image processing, so
+   enabling ACES scene-wide *will* shift eyes / eyebrows / mouth (ACES maps linear 1.0 to
+   ≈0.8 sRGB). This is the largest blast-radius risk in the change.
+
+4. **VRM export serializes the live scene.** `src/lib/babylon/export.ts:437` runs
+   `GLTF2Export` over the same `Scene` object. An in-place `emissiveColor *= 12.5` would be
+   written into the exported file as `emissiveFactor: 6.01`, which is out of the glTF-spec
+   `[0,1]` range.
+
+5. **Ordering is not fully reproducible.** Unity composites the whole frame in HDR, then
+   blooms, then tonemaps once. Babylon's material-level image processing tonemaps *per
+   material, before alpha blending*. For stacked transparent emissive surfaces (exactly this
+   wearable) the results will be close but not identical. Accepted for now; see step 5.
+
+6. `docs/ai-agent-context.md:32` claims Babylon.js 8.x — the installed version is
+   **4.2.2**. `TONEMAPPING_ACES` and the Hill `ACESFitted` implementation are present and
+   identical to later versions, so the plan holds either way, but the doc should be corrected.
+
+## Plan
+
+### Step 1 — Emissive gain (new module)
+
+New `src/lib/babylon/emissive.ts`:
+
+- `UNITY_EMISSIVE_GENERATOR_GAIN = 5` — `ToonMaterialGenerator.EMISSIVE_MAGIC_NUMBER`
+- `UNITY_EMISSIVE_SHADER_GAIN = 2.5` — `DCL_ToonBodyDoubleShadeWithFeather.hlsl:382`
+- `UNITY_EMISSIVE_GAIN = UNITY_EMISSIVE_GENERATOR_GAIN * UNITY_EMISSIVE_SHADER_GAIN`
+- `applyUnityEmissiveGain(material: PBRMaterial): void` — scales `emissiveColor`, records the
+  original on `material.metadata.originalEmissiveColor`, and no-ops if already applied.
+
+Keeping the two factors separate and named after their source keeps the link to
+`aang-renderer` traceable when either side changes.
+
+Call it from the existing cleanup loop in `src/lib/babylon/wearable.ts:39-48`. That loop is
+the single funnel for every glTF material in the scene — body shape included, since the body
+shape is itself loaded through `loadWearable`.
+
+Idempotency matters: options updates re-render, and the guard prevents compounding.
+
+### Step 2 — ACES tonemapping, with an exposure lift
+
+In `createScene` (`src/lib/babylon/scene.ts`), after the scene is constructed:
+
+```ts
+root.imageProcessingConfiguration.toneMappingEnabled = true
+root.imageProcessingConfiguration.toneMappingType = ImageProcessingConfiguration.TONEMAPPING_ACES
+root.imageProcessingConfiguration.exposure = getToneMappingExposure()
+```
+
+Scene-level (not `DefaultRenderingPipeline`) — see constraints 1 and 2.
+
+**The exposure lift was not in the original plan and turned out to be required.** ACES
+expects HDR input with headroom above 1.0. Unity's scene has it (many lights, GI, and the
+emissive gain); this scene does not — its four lights sum to roughly 1.0 — so tonemapping
+the raw values crushes the dark end. Measured on the reference wearable's *non-emissive*
+material, which should not have moved at all:
+
+| | outer feathers (emissive) | inner shape (non-emissive) |
+| - | - | - |
+| Unity (target) | `#FBE9BA` | `#751610` |
+| Babylon before | `#F6AD9E` | `#982218` |
+| ACES, exposure 1 | `#EFAD86` | `#400E0A` ← worse than before |
+| **ACES, exposure 2 (shipped)** | **`#F9D2AF`** | **`#6D150F`** |
+| ACES, exposure 3 | `#FADFC3` | `#7D1913` |
+
+Exposure 1 would have traded the emissive bug for a darker catalogue. 2.0 is the
+conventional compensation for ACES over LDR-authored content and lands the non-emissive
+material within a few units of Unity. 3.0 fits *this item's* feathers better but is a larger
+lift than has been validated against skin and facial features, so it is not the default.
+`?exposure=` overrides it for QA sweeps.
+
+### Step 3 — Keep the GlowLayer from compounding
+
+With emissive at ×12.5 the existing `GlowLayer` (`scene.ts:235-238`) reads a 12.5× brighter
+source and will bleed enormously. Feed it the pre-gain value:
+
+```ts
+glowLayer.customEmissiveColorSelector = (mesh, subMesh, material, result) => {
+  const original = (material as PBRMaterial).metadata?.originalEmissiveColor
+  ...
+}
+```
+
+Alternative if that proves fiddly: scale `glowLayer.intensity` down by `UNITY_EMISSIVE_GAIN`.
+Either way the goal for this step is *no visible change* to glow — it is not the thing being
+fixed, and holding it constant keeps step 2's effect readable in review.
+
+### Step 4 — Protect the VRM export
+
+`export.ts` already post-processes the serialized JSON (`stripAnimations`,
+`applyUnlitMaterials`). Add a `normalizeEmissiveForExport(json)` alongside them that divides
+`emissiveFactor` by `UNITY_EMISSIVE_GAIN` and clamps to `[0,1]`, so exported files stay
+spec-valid regardless of what the preview does for display.
+
+### Step 5 — Deferred: bloom and HDR compositing
+
+Not in this change. True parity (composite in HDR → bloom → tonemap once) requires a
+`DefaultRenderingPipeline`, which per constraint 1 first requires migrating `getScreenshot`
+off `CreateScreenshotUsingRenderTarget` — `preserveDrawingBuffer: true` is already set at
+`scene.ts:105-109`, so `CreateScreenshotAsync` against the canvas is a viable target — and
+per constraint 2 requires extending `ignoreTextureList`. Separate PR.
+
+### Step 6 — Backface culling
+
+`ToonMaterialGenerator.cs:95` hardcodes `CullMode.Back`, ignoring the glTF `doubleSided`
+flag; Babylon honours it. On the reference wearable — whose materials both declare
+`"doubleSided": true` — every flat feather card drew from both sides, so Babylon showed the
+full fan from the front *and* the back while Unity shows a subset from the front and the
+full spread from the back.
+
+`src/lib/babylon/culling.ts` forces `backFaceCulling = true` on every material in the
+container, applied outside the `instanceof PBRMaterial` branch in `wearable.ts` because
+Unity applies it to every material it generates, PBR or not. Measured subject coverage:
+
+| view | doubleSided (before) | culled (after) |
+| - | - | - |
+| front | 88707 px | 61983 px |
+| back | 115874 px | 88125 px |
+
+Own escape hatch, `?culling=none`, kept separate from `?toneMapping=none`: this overrides
+what the asset file itself declares and changes silhouettes anywhere authors relied on
+double-sided geometry, so it needs to be rollback-able on its own. Arguably Unity is the one
+misbehaving against the glTF spec here — matching it is a deliberate choice to follow the
+reference look, and still deserves a catalogue-wide check for wearables that now show holes
+(hair cards, skirts, capes are the likely candidates).
+
+### QA escape hatch
+
+`?toneMapping=none` rolls back the whole change — the gain *and* the tonemapping together,
+since the gain without a tonemapper to compress it is worse than neither. `?exposure=N`
+sweeps the lift. Both read `window.location.search` directly rather than going through
+`PreviewConfig`, which lives in `@dcl/schemas` and would need a release to extend.
+
+## Status
+
+Steps 1–4, step 6, and the escape hatches are implemented. Step 5 (bloom / HDR compositing)
+remains deferred as planned.
+
+**Two known residual gaps against Unity**, both from step 5 being deferred:
+
+- Feathers land at `#F9D2AF` against Unity's `#FBE9BA` — still slightly warmer and less
+  bright, because Unity's bloom (threshold 1, intensity 1) pushes its highlights further
+  toward white than a tonemapper alone can.
+- Unity composites the whole frame in HDR then tonemaps once; this change tonemaps per
+  material, before alpha blending (constraint 5). Stacked transparent emissive surfaces —
+  exactly this wearable — will stay close but never identical.
+
+**V4 could not be validated locally.** The Babylon avatar renders blank on the local dev
+server, including with `?toneMapping=none`, so the failure is environmental and predates this
+change — but it means skin, hair and facial features have *not* been checked against the
+tonemapping. That is the highest-risk case (constraint 3) and the reason the exposure default
+is the conservative 2.0 rather than the better-fitting 3.0. **Run V4 in a working environment
+before merging**, and re-evaluate the exposure default there.
+
+## Test cases
+
+The repo currently has **no tests** — `npm test` runs jest with no config and no test files.
+Step 1 of testing is therefore standing up a jest + ts config that can import from `src/`.
+
+### Unit
+
+| # | Target | Case | Expected |
+| - | ------ | ---- | -------- |
+| U1 | `UNITY_EMISSIVE_GAIN` | composition | `=== 12.5`, and `=== GENERATOR_GAIN * SHADER_GAIN` |
+| U2 | `applyUnityEmissiveGain` | `emissiveColor = (0.4812, 0, 0.0036)` | becomes `(6.015, 0, 0.0453)` |
+| U3 | `applyUnityEmissiveGain` | `emissiveColor = (0,0,0)` | stays `(0,0,0)` |
+| U4 | `applyUnityEmissiveGain` | called twice on the same material | gain applied once (idempotent) |
+| U5 | `applyUnityEmissiveGain` | original preserved | `metadata.originalEmissiveColor` equals the pre-gain value |
+| U6 | `loadWearable` cleanup | non-`PBRMaterial` in container | left untouched |
+| U7 | `normalizeEmissiveForExport` | `emissiveFactor: [6.015, 0, 0.0453]` | back to `[0.4812, 0, 0.0036]`, all channels within `[0,1]` |
+| U8 | `normalizeEmissiveForExport` | material with no `emissiveFactor` | no-op, no crash |
+
+### Rendering / integration
+
+These need a Babylon scene in a headless GL context (or the manual matrix below). Worth doing
+headless for at least R1–R3, since those are the assertions that would catch a silent
+regression later.
+
+| # | Case | Expected |
+| - | ---- | -------- |
+| R1 | Load the reference GLB, assert material state after `loadWearable` | `Material.001.emissiveColor ≈ (6.015, 0, 0.0453)`; `Material.002` stays `(0,0,0)` |
+| R2 | `scene.imageProcessingConfiguration` after `createScene` | `toneMappingEnabled === true`, `toneMappingType === TONEMAPPING_ACES` |
+| R3 | `getMetrics()` texture count, before vs after the change | unchanged (guards constraint 2 — fails loudly if someone later adds a pipeline) |
+| R4 | `exportVRM` on a scene containing the reference wearable | serialized `emissiveFactor` all within `[0,1]` |
+
+### Visual matrix (manual, both renderers side by side)
+
+Run each as `?...&unity=true` and `?...&unity=false` and compare. This is the real coverage
+for a shading change.
+
+| # | Case | What to check |
+| - | ---- | ------------- |
+| V1 | `Hell's Angels`, wearable mode — the reported item | Babylon now shows pale cream feathers with the fire texture washed out, matching Unity |
+| V2 | Same item, avatar mode | same result on a full avatar |
+| V3 | A wearable with `emissiveFactor = 0` | only the global ACES shift, no gain effect; still recognisably the same item |
+| V4 | Default avatar, facial features | eyes / eyebrows / mouth still legible and correctly hued (constraint 3 — highest risk) |
+| V5 | `skinColor` / `hairColor` at extremes (near-black, near-white) | no clipping, no muddiness |
+| V6 | Emote preview (`&emote=`) | non-`WEARABLE` types get no directional/spot light (`scene.ts:222-227`); confirm ACES doesn't make these noticeably darker |
+| V7 | Glow bleed on any emissive item, before vs after | unchanged (step 3 succeeded) |
+| V8 | `disableBackground=true` vs a solid background colour | transparent background unaffected; no halo at the alpha edge |
+| V9 | `getScreenshot` RPC output vs the live canvas | pixel-identical treatment (constraint 1) |
+| V10 | iOS / Safari | `GlowLayer` is skipped there (`scene.ts:235`); confirm the tonemapped result still looks right without it |
+| V11 | Shop embed, a page of item cards | thumbnails regenerate consistently; spot-check a range of rarities |
+| V12 | A wearable with an emissive **texture** (not just a factor) | gain applies to the factor only; texture-driven emissives don't blow out |
+
+### Regression sweep
+
+Because this changes every wearable with a non-zero `emissiveFactor` *and* shifts overall
+tone for everything else, before merging: capture before/after screenshots across a sample
+of the catalogue (a few dozen items spanning categories and rarities, plus the base avatars)
+and diff them. Items that change *unexpectedly* — i.e. anything with `emissiveFactor = 0`
+moving more than the flat ACES shift — indicate a bug in step 1's scoping.

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,10 +38,12 @@
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.5.1",
         "dotenv": "^16.5.0",
+        "jsdom": "^29.1.1",
         "prettier": "^3.5.3",
         "rollup": "^4.42.0",
         "typescript": "^5.2.2",
-        "vite": "^6.3.5"
+        "vite": "^6.3.5",
+        "vitest": "^3.2.7"
       },
       "engines": {
         "node": "22"
@@ -59,6 +61,57 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -495,6 +548,159 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@date-fns/upgrade": {
@@ -992,6 +1198,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@fluentui/react-component-event-listener": {
       "version": "0.63.1",
       "resolved": "https://registry.npmjs.org/@fluentui/react-component-event-listener/-/react-component-event-listener-0.63.1.tgz",
@@ -1113,7 +1337,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
       "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1128,17 +1351,38 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
+    "node_modules/@jridgewell/source-map/node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1794,6 +2038,17 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
@@ -1857,6 +2112,13 @@
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/deep-equal/-/deep-equal-1.0.1.tgz",
@@ -1914,7 +2176,6 @@
       "version": "22.15.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
       "integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1923,14 +2184,12 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
-      "dev": true
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
     },
     "node_modules/@types/react": {
       "version": "18.3.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
       "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1941,7 +2200,6 @@
       "version": "18.3.0",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
@@ -2002,6 +2260,309 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@webassemblyjs/ast": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-buffer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-numbers": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-wasm-section": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/ieee754": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "node_modules/@webassemblyjs/leb128": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/utf8": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/wasm-edit": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-gen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-opt": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-parser": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wast-printer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "license": "Apache-2.0",
+      "peer": true
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2016,6 +2577,48 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -2063,6 +2666,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -2104,6 +2717,28 @@
       "integrity": "sha512-zheJpzwyNrG4t39vusA67v3BYg1HTVXOF8cErPEHzWK88PEOFwgo6Ea9VHOgOWNMgeuOtFVtB73NE2NWl9uDyQ==",
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -2113,10 +2748,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
-      "integrity": "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==",
-      "dev": true,
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "funding": [
         {
           "type": "opencollective",
@@ -2133,16 +2767,34 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001718",
-        "electron-to-chromium": "^1.5.160",
-        "node-releases": "^2.0.19",
-        "update-browserslist-db": "^1.1.3"
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/call-bind": {
@@ -2193,10 +2845,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001721",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001721.tgz",
-      "integrity": "sha512-cOuvmUVtKrtEaoKiO0rSc29jcjwMwX5tOHDy4MgVFEWiUXj4uBMJkwI8MDySkgXidpMiHUcviogAvFi4pA2hDQ==",
-      "dev": true,
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -2213,6 +2864,43 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chrome-trace-event": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/classnames": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
@@ -2227,6 +2915,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/core-js-pure": {
       "version": "3.19.1",
@@ -2245,6 +2940,20 @@
       "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
       "integrity": "sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==",
       "license": "BSD"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
@@ -2378,6 +3087,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/date-fns": {
       "version": "2.29.3",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
@@ -2412,12 +3135,13 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -2563,6 +3287,13 @@
         "object-assign": "^4.1.1"
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -2576,6 +3307,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-equal": {
@@ -2703,10 +3444,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.165",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.165.tgz",
-      "integrity": "sha512-naiMx1Z6Nb2TxPU6fiFrUrDTjyPMLdTtaOd2oLmG8zVSg2hCWGkhPyxwk+qRmZ1ytwVqUv0u7ZcDA5+ALhaUtw==",
-      "dev": true,
+      "version": "1.5.402",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.402.tgz",
+      "integrity": "sha512-/oOpMaPT6Yg+6/1XQhyIPlzgj7Ye9zf+nNM2Uh6OcE2G2oNptWazFa+qB2Pdqqbsc9KnIDzgAntoYN0dbwOXwA==",
       "license": "ISC"
     },
     "node_modules/emojis-list": {
@@ -2715,6 +3455,33 @@
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -2754,6 +3521,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -2812,10 +3586,66 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esrecurse/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/ethereum-blockies": {
@@ -2844,6 +3674,16 @@
       "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
       "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3031,6 +3871,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC",
+      "peer": true
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -3047,7 +3894,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3102,6 +3948,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/hyphenate-style-name": {
@@ -3276,6 +4135,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -3474,6 +4340,21 @@
         "node": ">= 10.14.2"
       }
     },
+    "node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
     "node_modules/jquery": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
@@ -3484,6 +4365,47 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -3556,6 +4478,23 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
@@ -3563,6 +4502,16 @@
       "dev": true,
       "bin": {
         "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/matchmediaquery": {
@@ -3583,6 +4532,30 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -3590,6 +4563,67 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/minimizer-webpack-plugin": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
+      "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "terser": "^5.31.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
       }
     },
     "node_modules/mitt": {
@@ -3615,10 +4649,11 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -3639,12 +4674,21 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
-      "dev": true,
-      "license": "MIT"
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -3728,6 +4772,36 @@
       "integrity": "sha512-hrqldJHokR3Qj88EIlV/kAyAi/G5R2+R56TBANxNMy0uPlYcttx0jnMW6Yx5KsKPSbC3KddM/7qQm3+0wEXKxg==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -3738,8 +4812,20 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -3832,9 +4918,10 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -4182,6 +5269,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -4190,6 +5290,63 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/schema-utils/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semantic-ui-css": {
       "version": "2.5.0",
@@ -4350,6 +5507,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signum": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/signum/-/signum-1.0.0.tgz",
@@ -4360,11 +5524,45 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -4391,10 +5589,100 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.2.tgz",
+      "integrity": "sha512-rGbJiKeQ4WDe3EXlDAIaQcwftVfv2Q8o1awFNfvXolJYKkb1AuZY1RTOmqx4LJXZENbWZA7eIsYGHuEzHsi1nQ==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
@@ -4414,18 +5702,55 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
+        "node": "^18.0.0 || >=20.0.0"
       }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/to-px": {
       "version": "1.1.0",
@@ -4476,6 +5801,32 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -4495,18 +5846,26 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
-      "dev": true,
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.0.tgz",
+      "integrity": "sha512-x/M6q3w4Ybp91CNaS4S69UnliqR3BzRpOT6LWbksjth0S/+jhfaPJsWjt/TewpT8j9eLIojUf5jr29WextHroA==",
       "funding": [
         {
           "type": "opencollective",
@@ -4651,17 +6010,27 @@
         }
       }
     },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
       "engines": {
-        "node": ">=12"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/vite/node_modules/postcss": {
@@ -4693,14 +6062,90 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/vite/node_modules/source-map-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
       "dev": true,
-      "license": "BSD-3-Clause",
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/warning": {
@@ -4712,10 +6157,126 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/watchpack": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+      "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/web-vitals": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-1.1.2.tgz",
       "integrity": "sha512-PFMKIY+bRSXlMxVAQ+m2aw9c/ioUYfDgrYot0YUa+/xa0sakubWhSDyxAKwzymvXVdF4CZI71g06W+mqhzu6ig=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/webpack": {
+      "version": "5.109.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.109.2.tgz",
+      "integrity": "sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "@types/json-schema": "^7.0.15",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.16.0",
+        "browserslist": "^4.28.1",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.24.4",
+        "es-module-lexer": "^2.1.0",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "graceful-fs": "^4.2.11",
+        "mime-db": "^1.54.0",
+        "minimizer-webpack-plugin": "^5.6.1",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "watchpack": "^2.5.2",
+        "webpack-sources": "^3.5.1"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-sources": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.1.tgz",
+      "integrity": "sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack/node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/webpack/node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.1.1",
@@ -4774,6 +6335,40 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "start": "vite",
     "build": "vite build",
     "build:static-local": "GEN_STATIC_LOCAL=true npm run build && mv ./dist ./static-local",
-    "test": "jest",
+    "test": "vitest run",
     "prebuild": "node ./scripts/prebuild.cjs",
     "update-unity": "node ./scripts/update-unity.cjs"
   },
@@ -73,9 +73,11 @@
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.5.1",
     "dotenv": "^16.5.0",
+    "jsdom": "^29.1.1",
     "prettier": "^3.5.3",
     "rollup": "^4.42.0",
     "typescript": "^5.2.2",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^3.2.7"
   }
 }

--- a/src/lib/babylon/culling.test.ts
+++ b/src/lib/babylon/culling.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { applyUnityBackFaceCulling, isUnityBackFaceCullingEnabled } from './culling'
+
+function setSearch(search: string) {
+  window.history.replaceState({}, '', `/${search}`)
+}
+
+afterEach(() => setSearch(''))
+
+// Only backFaceCulling is touched, so a stand-in keeps these off a WebGL context.
+const fakeMaterial = (backFaceCulling: boolean) => ({ backFaceCulling }) as any
+
+describe('applyUnityBackFaceCulling', () => {
+  it('overrides the glTF doubleSided flag, which Babylon maps to backFaceCulling=false', () => {
+    const material = fakeMaterial(false)
+
+    applyUnityBackFaceCulling(material)
+
+    expect(material.backFaceCulling).toBe(true)
+  })
+
+  it('leaves already-culled materials alone', () => {
+    const material = fakeMaterial(true)
+
+    applyUnityBackFaceCulling(material)
+
+    expect(material.backFaceCulling).toBe(true)
+  })
+})
+
+describe('the culling=none escape hatch', () => {
+  it('is off by default, so wearables match Unity', () => {
+    expect(isUnityBackFaceCullingEnabled()).toBe(true)
+  })
+
+  it('restores the glTF doubleSided behaviour', () => {
+    setSearch('?culling=none')
+    const material = fakeMaterial(false)
+
+    applyUnityBackFaceCulling(material)
+
+    expect(isUnityBackFaceCullingEnabled()).toBe(false)
+    expect(material.backFaceCulling).toBe(false)
+  })
+
+  it('is independent of the tonemapping switch', () => {
+    setSearch('?toneMapping=none')
+    expect(isUnityBackFaceCullingEnabled()).toBe(true)
+  })
+})

--- a/src/lib/babylon/culling.test.ts
+++ b/src/lib/babylon/culling.test.ts
@@ -1,11 +1,8 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { applyUnityBackFaceCulling, isUnityBackFaceCullingEnabled } from './culling'
+import { cleanupSearchAfterEach, setSearch } from './test-helpers'
 
-function setSearch(search: string) {
-  window.history.replaceState({}, '', `/${search}`)
-}
-
-afterEach(() => setSearch(''))
+cleanupSearchAfterEach()
 
 // Only backFaceCulling is touched, so a stand-in keeps these off a WebGL context.
 const fakeMaterial = (backFaceCulling: boolean) => ({ backFaceCulling }) as any

--- a/src/lib/babylon/culling.ts
+++ b/src/lib/babylon/culling.ts
@@ -11,8 +11,19 @@ import { Material } from '@babylonjs/core'
  * reference look wins — but it changes silhouettes anywhere authors relied on double-sided
  * geometry, so it gets its own escape hatch rather than riding along with the tonemapping.
  */
+let _cachedSearch = ''
+let _cachedParams: URLSearchParams | null = null
+function getSearchParams(): URLSearchParams {
+  const search = window.location.search
+  if (!_cachedParams || search !== _cachedSearch) {
+    _cachedSearch = search
+    _cachedParams = new URLSearchParams(search)
+  }
+  return _cachedParams
+}
+
 export function isUnityBackFaceCullingEnabled(): boolean {
-  return new URLSearchParams(window.location.search).get('culling') !== 'none'
+  return getSearchParams().get('culling') !== 'none'
 }
 
 export function applyUnityBackFaceCulling(material: Material): void {

--- a/src/lib/babylon/culling.ts
+++ b/src/lib/babylon/culling.ts
@@ -1,0 +1,24 @@
+import { Material } from '@babylonjs/core'
+
+/**
+ * Unity (aang-renderer) ignores the glTF `doubleSided` flag and culls back faces on every
+ * material — `ToonMaterialGenerator` sets `CullMode.Back` unconditionally. Babylon honours
+ * the flag, so a double-sided wearable draws each face twice: flat cards like feathers,
+ * hair strands and capes stay visible from behind instead of disappearing, which reads as
+ * "too many feathers" next to the Unity reference.
+ *
+ * Matching Unity means overriding the file's own declaration. That is deliberate — the
+ * reference look wins — but it changes silhouettes anywhere authors relied on double-sided
+ * geometry, so it gets its own escape hatch rather than riding along with the tonemapping.
+ */
+export function isUnityBackFaceCullingEnabled(): boolean {
+  return new URLSearchParams(window.location.search).get('culling') !== 'none'
+}
+
+export function applyUnityBackFaceCulling(material: Material): void {
+  if (!isUnityBackFaceCullingEnabled()) {
+    return
+  }
+
+  material.backFaceCulling = true
+}

--- a/src/lib/babylon/emissive.test.ts
+++ b/src/lib/babylon/emissive.test.ts
@@ -1,5 +1,5 @@
 import { Color3 } from '@babylonjs/core/Maths/math.color'
-import { afterEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import {
   applyUnityEmissiveGain,
   getOriginalEmissiveColor,
@@ -10,12 +10,9 @@ import {
   UNITY_EMISSIVE_GENERATOR_GAIN,
   UNITY_EMISSIVE_SHADER_GAIN,
 } from './emissive'
+import { cleanupSearchAfterEach, setSearch } from './test-helpers'
 
-function setSearch(search: string) {
-  window.history.replaceState({}, '', `/${search}`)
-}
-
-afterEach(() => setSearch(''))
+cleanupSearchAfterEach()
 
 // The gain only touches emissiveColor and metadata, so a plain stand-in keeps these tests
 // off a WebGL context. Cast at the call site to satisfy the PBRMaterial signature.

--- a/src/lib/babylon/emissive.test.ts
+++ b/src/lib/babylon/emissive.test.ts
@@ -1,0 +1,133 @@
+import { Color3 } from '@babylonjs/core/Maths/math.color'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  applyUnityEmissiveGain,
+  getOriginalEmissiveColor,
+  getToneMappingExposure,
+  isUnityToneMappingEnabled,
+  TONE_MAPPING_EXPOSURE,
+  UNITY_EMISSIVE_GAIN,
+  UNITY_EMISSIVE_GENERATOR_GAIN,
+  UNITY_EMISSIVE_SHADER_GAIN,
+} from './emissive'
+
+function setSearch(search: string) {
+  window.history.replaceState({}, '', `/${search}`)
+}
+
+afterEach(() => setSearch(''))
+
+// The gain only touches emissiveColor and metadata, so a plain stand-in keeps these tests
+// off a WebGL context. Cast at the call site to satisfy the PBRMaterial signature.
+function fakeMaterial(emissiveColor = new Color3(0, 0, 0)) {
+  return { emissiveColor, metadata: undefined } as any
+}
+
+// Hell's Angels (0x65ed61c4fc2d1102ed574a48e664b90b7a300ea8 item 0), the wearable that
+// surfaced the Babylon/Unity divergence.
+const REFERENCE_EMISSIVE = new Color3(0.48118668795180497, 0, 0.0036217522927073365)
+
+describe('UNITY_EMISSIVE_GAIN', () => {
+  it('is the product of the two Unity multipliers', () => {
+    expect(UNITY_EMISSIVE_GENERATOR_GAIN).toBe(5)
+    expect(UNITY_EMISSIVE_SHADER_GAIN).toBe(2.5)
+    expect(UNITY_EMISSIVE_GAIN).toBe(UNITY_EMISSIVE_GENERATOR_GAIN * UNITY_EMISSIVE_SHADER_GAIN)
+    expect(UNITY_EMISSIVE_GAIN).toBe(12.5)
+  })
+})
+
+describe('applyUnityEmissiveGain', () => {
+  it('scales the emissive to match Unity', () => {
+    const material = fakeMaterial(REFERENCE_EMISSIVE.clone())
+
+    applyUnityEmissiveGain(material)
+
+    expect(material.emissiveColor.r).toBeCloseTo(6.0148, 4)
+    expect(material.emissiveColor.g).toBeCloseTo(0, 4)
+    expect(material.emissiveColor.b).toBeCloseTo(0.04527, 4)
+  })
+
+  it('leaves non-emissive materials black', () => {
+    const material = fakeMaterial(new Color3(0, 0, 0))
+
+    applyUnityEmissiveGain(material)
+
+    expect(material.emissiveColor.asArray()).toEqual([0, 0, 0])
+  })
+
+  it('does not compound when a re-render applies it again', () => {
+    const material = fakeMaterial(REFERENCE_EMISSIVE.clone())
+
+    applyUnityEmissiveGain(material)
+    const afterFirst = material.emissiveColor.clone()
+    applyUnityEmissiveGain(material)
+
+    expect(material.emissiveColor.asArray()).toEqual(afterFirst.asArray())
+  })
+
+  it('preserves the original color for the glow layer and the export', () => {
+    const material = fakeMaterial(REFERENCE_EMISSIVE.clone())
+
+    applyUnityEmissiveGain(material)
+
+    expect(getOriginalEmissiveColor(material).asArray()).toEqual(REFERENCE_EMISSIVE.asArray())
+  })
+
+  it('keeps unrelated metadata set by other passes', () => {
+    const material = fakeMaterial(REFERENCE_EMISSIVE.clone())
+    material.metadata = { gltf: { pointer: '/materials/0' } }
+
+    applyUnityEmissiveGain(material)
+
+    expect(material.metadata.gltf).toEqual({ pointer: '/materials/0' })
+  })
+})
+
+describe('the toneMapping=none escape hatch', () => {
+  it('is off by default, so the fix ships enabled', () => {
+    expect(isUnityToneMappingEnabled()).toBe(true)
+  })
+
+  it('rolls the gain back too — the gain without a tonemapper is worse than neither', () => {
+    setSearch('?toneMapping=none')
+    const material = fakeMaterial(REFERENCE_EMISSIVE.clone())
+
+    applyUnityEmissiveGain(material)
+
+    expect(isUnityToneMappingEnabled()).toBe(false)
+    expect(material.emissiveColor.asArray()).toEqual(REFERENCE_EMISSIVE.asArray())
+    expect(material.metadata?.originalEmissiveColor).toBeUndefined()
+  })
+
+  it('is not triggered by other values', () => {
+    setSearch('?toneMapping=aces')
+    expect(isUnityToneMappingEnabled()).toBe(true)
+  })
+})
+
+describe('getToneMappingExposure', () => {
+  it('lifts the scene by default — ACES over un-lifted LDR crushes the dark end', () => {
+    expect(getToneMappingExposure()).toBe(TONE_MAPPING_EXPOSURE)
+    expect(TONE_MAPPING_EXPOSURE).toBeGreaterThan(1)
+  })
+
+  it('honours ?exposure= so QA can sweep it', () => {
+    setSearch('?exposure=3')
+    expect(getToneMappingExposure()).toBe(3)
+  })
+
+  it('falls back to the default for junk and non-positive values', () => {
+    for (const value of ['abc', '0', '-1', '']) {
+      setSearch(`?exposure=${value}`)
+      expect(getToneMappingExposure()).toBe(TONE_MAPPING_EXPOSURE)
+    }
+  })
+})
+
+describe('getOriginalEmissiveColor', () => {
+  it('falls back to the current color when the gain was never applied', () => {
+    const material = fakeMaterial(REFERENCE_EMISSIVE.clone())
+
+    expect(getOriginalEmissiveColor(material).asArray()).toEqual(REFERENCE_EMISSIVE.asArray())
+  })
+})

--- a/src/lib/babylon/emissive.ts
+++ b/src/lib/babylon/emissive.ts
@@ -1,0 +1,81 @@
+import { Color3, PBRMaterial } from '@babylonjs/core'
+
+/**
+ * Unity (aang-renderer) is the reference look, and it amplifies the glTF
+ * `emissiveFactor` twice before tonemapping it. Babylon applies the factor 1:1,
+ * so emissive wearables render as saturated raw colors instead of the blown-out
+ * highlights Unity produces. These constants mirror the two Unity multipliers so
+ * the link stays traceable if either side changes.
+ */
+
+/** `ToonMaterialGenerator.EMISSIVE_MAGIC_NUMBER` in aang-renderer. */
+export const UNITY_EMISSIVE_GENERATOR_GAIN = 5
+
+/** The `* 2.5f` applied to `_Emissive_Color` in DCL_ToonBodyDoubleShadeWithFeather.hlsl. */
+export const UNITY_EMISSIVE_SHADER_GAIN = 2.5
+
+export const UNITY_EMISSIVE_GAIN = UNITY_EMISSIVE_GENERATOR_GAIN * UNITY_EMISSIVE_SHADER_GAIN
+
+/**
+ * ACES expects HDR input with headroom above 1.0. Unity's scene has it (many lights, GI, and
+ * the emissive gain above); this scene does not — its four lights sum to roughly 1.0 — so
+ * tonemapping the raw values crushes everything dark. Without this lift the fix would trade
+ * the emissive bug for a darker catalogue: on the reference wearable the non-emissive
+ * material fell from #982218 to #400E0A against Unity's #751610.
+ *
+ * 2.0 is the conventional compensation for ACES over LDR-authored content and lands the
+ * non-emissive material on #6D150F. Overridable via ?exposure= for QA sweeps — 3.0 fits the
+ * reference wearable's emissive feathers more closely, but is a larger lift than has been
+ * validated against skin and facial features.
+ */
+export const TONE_MAPPING_EXPOSURE = 2.0
+
+type EmissiveMetadata = {
+  originalEmissiveColor?: Color3
+}
+
+/**
+ * QA escape hatch to A/B the same URL during review, and to unblock support if this
+ * regresses something in production. Gates the gain and the tonemapping together: the gain
+ * only makes sense with a tonemapper to compress it, so half of the pair is worse than
+ * neither. Not part of PreviewConfig because that type lives in @dcl/schemas and would need
+ * a release to extend.
+ */
+export function isUnityToneMappingEnabled(): boolean {
+  return new URLSearchParams(window.location.search).get('toneMapping') !== 'none'
+}
+
+/** {@link TONE_MAPPING_EXPOSURE}, unless ?exposure= overrides it for a QA sweep. */
+export function getToneMappingExposure(): number {
+  const override = Number(new URLSearchParams(window.location.search).get('exposure'))
+  return Number.isFinite(override) && override > 0 ? override : TONE_MAPPING_EXPOSURE
+}
+
+/**
+ * Reads back the emissive color a material had before {@link applyUnityEmissiveGain}
+ * scaled it. Returns the current color for materials that were never scaled.
+ */
+export function getOriginalEmissiveColor(material: PBRMaterial): Color3 {
+  const metadata = material.metadata as EmissiveMetadata | undefined
+  return metadata?.originalEmissiveColor ?? material.emissiveColor
+}
+
+/**
+ * Scales a material's emissive to match Unity's, keeping the original around for
+ * the glow layer and the VRM export. Safe to call twice: re-renders (triggered by
+ * option updates) would otherwise compound the gain.
+ */
+export function applyUnityEmissiveGain(material: PBRMaterial): void {
+  if (!isUnityToneMappingEnabled()) {
+    return
+  }
+
+  const metadata = (material.metadata ?? {}) as EmissiveMetadata
+  if (metadata.originalEmissiveColor) {
+    return
+  }
+
+  metadata.originalEmissiveColor = material.emissiveColor.clone()
+  material.metadata = metadata
+  material.emissiveColor = material.emissiveColor.scale(UNITY_EMISSIVE_GAIN)
+}

--- a/src/lib/babylon/emissive.ts
+++ b/src/lib/babylon/emissive.ts
@@ -31,6 +31,17 @@ type EmissiveMetadata = {
   originalEmissiveColor?: Color3
 }
 
+let _cachedSearch = ''
+let _cachedParams: URLSearchParams | null = null
+function getSearchParams(): URLSearchParams {
+  const search = window.location.search
+  if (!_cachedParams || search !== _cachedSearch) {
+    _cachedSearch = search
+    _cachedParams = new URLSearchParams(search)
+  }
+  return _cachedParams
+}
+
 /**
  * QA escape hatch to A/B the same URL during review, and to unblock support if this
  * regresses something in production. Gates the gain and the tonemapping together: the gain
@@ -39,12 +50,12 @@ type EmissiveMetadata = {
  * a release to extend.
  */
 export function isUnityToneMappingEnabled(): boolean {
-  return new URLSearchParams(window.location.search).get('toneMapping') !== 'none'
+  return getSearchParams().get('toneMapping') !== 'none'
 }
 
 /** {@link TONE_MAPPING_EXPOSURE}, unless ?exposure= overrides it for a QA sweep. */
 export function getToneMappingExposure(): number {
-  const override = Number(new URLSearchParams(window.location.search).get('exposure'))
+  const override = Number(getSearchParams().get('exposure'))
   return Number.isFinite(override) && override > 0 ? override : TONE_MAPPING_EXPOSURE
 }
 

--- a/src/lib/babylon/emissive.ts
+++ b/src/lib/babylon/emissive.ts
@@ -17,18 +17,15 @@ export const UNITY_EMISSIVE_SHADER_GAIN = 2.5
 export const UNITY_EMISSIVE_GAIN = UNITY_EMISSIVE_GENERATOR_GAIN * UNITY_EMISSIVE_SHADER_GAIN
 
 /**
- * ACES expects HDR input with headroom above 1.0. Unity's scene has it (many lights, GI, and
- * the emissive gain above); this scene does not — its four lights sum to roughly 1.0 — so
- * tonemapping the raw values crushes everything dark. Without this lift the fix would trade
- * the emissive bug for a darker catalogue: on the reference wearable the non-emissive
- * material fell from #982218 to #400E0A against Unity's #751610.
+ * Compensates for ACES crushing the dark end of this scene, which lacks the HDR headroom the
+ * tonemapper expects (its four lights sum to roughly 1.0).
  *
- * 2.0 is the conventional compensation for ACES over LDR-authored content and lands the
- * non-emissive material on #6D150F. Overridable via ?exposure= for QA sweeps — 3.0 fits the
- * reference wearable's emissive feathers more closely, but is a larger lift than has been
- * validated against skin and facial features.
+ * Measured against the Unity renderer over 10 marketplace wearables: mean avatar luminance
+ * lands within -2.8/255 of Unity at 1.2, against +20.3 at the 2.0 this shipped with initially.
+ * The optimum is flat from 1.1 to 1.3, so the exact value inside that band is not load-bearing.
+ * Overridable via ?exposure= for QA sweeps.
  */
-export const TONE_MAPPING_EXPOSURE = 2.0
+export const TONE_MAPPING_EXPOSURE = 1.2
 
 type EmissiveMetadata = {
   originalEmissiveColor?: Color3

--- a/src/lib/babylon/export.test.ts
+++ b/src/lib/babylon/export.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { normalizeEmissiveForExport } from './export'
+import { cleanupSearchAfterEach, setSearch } from './test-helpers'
+
+cleanupSearchAfterEach()
 
 describe('normalizeEmissiveForExport', () => {
   it('undoes the display gain so the file stays within the glTF [0,1] range', () => {
@@ -36,5 +39,16 @@ describe('normalizeEmissiveForExport', () => {
     const json = { meshes: [] }
 
     expect(() => normalizeEmissiveForExport(json)).not.toThrow()
+  })
+
+  it('skips normalization when toneMapping=none, since the gain was never applied', () => {
+    setSearch('?toneMapping=none')
+    const original = [0.48118668795180497, 0, 0.0036217522927073365]
+    const json = { materials: [{ emissiveFactor: [...original] }] }
+
+    normalizeEmissiveForExport(json)
+
+    // Values must remain untouched — dividing un-scaled emissive by 12.5 would crush them.
+    expect(json.materials[0].emissiveFactor).toEqual(original)
   })
 })

--- a/src/lib/babylon/export.test.ts
+++ b/src/lib/babylon/export.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeEmissiveForExport } from './export'
+
+describe('normalizeEmissiveForExport', () => {
+  it('undoes the display gain so the file stays within the glTF [0,1] range', () => {
+    // Hell's Angels (0x65ed61c4fc2d1102ed574a48e664b90b7a300ea8 item 0) as the scene holds
+    // it once applyUnityEmissiveGain has run.
+    const authored = [0.48118668795180497, 0, 0.0036217522927073365]
+    const json = { materials: [{ emissiveFactor: authored.map((channel) => channel * 12.5) }] }
+
+    normalizeEmissiveForExport(json)
+
+    expect(json.materials[0].emissiveFactor).toEqual(authored)
+    for (const channel of json.materials[0].emissiveFactor) {
+      expect(channel).toBeGreaterThanOrEqual(0)
+      expect(channel).toBeLessThanOrEqual(1)
+    }
+  })
+
+  it('clamps values that would still exceed the spec range', () => {
+    const json = { materials: [{ emissiveFactor: [100, -3, 0.5] }] }
+
+    normalizeEmissiveForExport(json)
+
+    expect(json.materials[0].emissiveFactor).toEqual([1, 0, 0.04])
+  })
+
+  it('ignores materials without an emissiveFactor', () => {
+    const json = { materials: [{ pbrMetallicRoughness: { metallicFactor: 0 } }] }
+
+    expect(() => normalizeEmissiveForExport(json)).not.toThrow()
+    expect(json.materials[0]).toEqual({ pbrMetallicRoughness: { metallicFactor: 0 } })
+  })
+
+  it('ignores documents with no materials array', () => {
+    const json = { meshes: [] }
+
+    expect(() => normalizeEmissiveForExport(json)).not.toThrow()
+  })
+})

--- a/src/lib/babylon/export.ts
+++ b/src/lib/babylon/export.ts
@@ -457,53 +457,55 @@ function uniquifyTextureNamesForExport(scene: Scene): () => void {
 }
 
 export async function exportVRM(scene: Scene): Promise<Blob> {
-  console.group('[VRM EXPORT DEBUG]')
-  console.log('Scene handedness:', scene.useRightHandedSystem ? 'right' : 'left')
+  if (process.env.VITE_REACT_APP_DEBUG) {
+    console.group('[VRM EXPORT DEBUG]')
+    console.log('Scene handedness:', scene.useRightHandedSystem ? 'right' : 'left')
 
-  const fmt = (arr: ArrayLike<number> | undefined) =>
-    arr ? JSON.stringify(Array.from(arr).map((v) => +v.toFixed(4))) : 'undefined'
+    const fmt = (arr: ArrayLike<number> | undefined) =>
+      arr ? JSON.stringify(Array.from(arr).map((v) => +v.toFixed(4))) : 'undefined'
 
-  const allRoots = scene.transformNodes.filter((n: TransformNode) => n.name === '__root__')
-  console.log(`Found ${allRoots.length} __root__ node(s):`)
-  allRoots.forEach((r: TransformNode, i: number) => {
-    console.log(
-      `  __root__[${i}]  scaling=${fmt(r.scaling.asArray())}  pos=${fmt(r.position.asArray())}  rot=${fmt(
-        r.rotationQuaternion?.asArray() ?? r.rotation.asArray(),
-      )}  parent=${r.parent?.name ?? '(scene root)'}  children=${r.getChildren().length}`,
-    )
-  })
-
-  const debugParent = scene.getMeshByName('parent')
-  if (debugParent) {
-    console.log(
-      `parent mesh: scaling=${fmt(debugParent.scaling.asArray())}  pos=${fmt(
-        debugParent.position.asArray(),
-      )}  rot=${fmt(
-        debugParent.rotationQuaternion?.asArray() ?? debugParent.rotation.asArray(),
-      )}  parent=${debugParent.parent?.name ?? '(scene root)'}  absPos=${fmt(
-        debugParent.getAbsolutePosition().asArray(),
-      )}`,
-    )
-  }
-
-  console.log(
-    'Top-level transform nodes:',
-    scene.transformNodes.filter((n: TransformNode) => !n.parent).map((n: TransformNode) => n.name),
-  )
-  console.log(
-    'Top-level meshes:',
-    scene.meshes.filter((m: AbstractMesh) => !m.parent).map((m: AbstractMesh) => m.name),
-  )
-
-  const probeBones = ['Avatar_Hips', 'Avatar_LeftHand', 'Avatar_RightHand', 'Avatar_LeftFoot', 'Avatar_RightFoot']
-  scene.skeletons.forEach((skel: Skeleton, i: number) => {
-    console.log(`Skeleton[${i}] "${skel.name}" bones=${skel.bones.length}`)
-    probeBones.forEach((name) => {
-      const bone = skel.bones.find((b: Bone) => b.name === name)
-      console.log(`  ${name} absolute=${fmt(bone?.getAbsoluteTransform().toArray())}`)
+    const allRoots = scene.transformNodes.filter((n: TransformNode) => n.name === '__root__')
+    console.log(`Found ${allRoots.length} __root__ node(s):`)
+    allRoots.forEach((r: TransformNode, i: number) => {
+      console.log(
+        `  __root__[${i}]  scaling=${fmt(r.scaling.asArray())}  pos=${fmt(r.position.asArray())}  rot=${fmt(
+          r.rotationQuaternion?.asArray() ?? r.rotation.asArray(),
+        )}  parent=${r.parent?.name ?? '(scene root)'}  children=${r.getChildren().length}`,
+      )
     })
-  })
-  console.groupEnd()
+
+    const debugParent = scene.getMeshByName('parent')
+    if (debugParent) {
+      console.log(
+        `parent mesh: scaling=${fmt(debugParent.scaling.asArray())}  pos=${fmt(
+          debugParent.position.asArray(),
+        )}  rot=${fmt(
+          debugParent.rotationQuaternion?.asArray() ?? debugParent.rotation.asArray(),
+        )}  parent=${debugParent.parent?.name ?? '(scene root)'}  absPos=${fmt(
+          debugParent.getAbsolutePosition().asArray(),
+        )}`,
+      )
+    }
+
+    console.log(
+      'Top-level transform nodes:',
+      scene.transformNodes.filter((n: TransformNode) => !n.parent).map((n: TransformNode) => n.name),
+    )
+    console.log(
+      'Top-level meshes:',
+      scene.meshes.filter((m: AbstractMesh) => !m.parent).map((m: AbstractMesh) => m.name),
+    )
+
+    const probeBones = ['Avatar_Hips', 'Avatar_LeftHand', 'Avatar_RightHand', 'Avatar_LeftFoot', 'Avatar_RightFoot']
+    scene.skeletons.forEach((skel: Skeleton, i: number) => {
+      console.log(`Skeleton[${i}] "${skel.name}" bones=${skel.bones.length}`)
+      probeBones.forEach((name) => {
+        const bone = skel.bones.find((b: Bone) => b.name === name)
+        console.log(`  ${name} absolute=${fmt(bone?.getAbsoluteTransform().toArray())}`)
+      })
+    })
+    console.groupEnd()
+  }
 
   const parentMesh = scene.getMeshByName('parent')
 

--- a/src/lib/babylon/export.ts
+++ b/src/lib/babylon/export.ts
@@ -1,6 +1,6 @@
 import { AbstractMesh, Bone, Matrix, Quaternion, Scene, Skeleton, TransformNode, Vector3 } from '@babylonjs/core'
 import { GLTF2Export } from '@babylonjs/serializers/glTF'
-import { UNITY_EMISSIVE_GAIN } from './emissive'
+import { isUnityToneMappingEnabled, UNITY_EMISSIVE_GAIN } from './emissive'
 
 // Maps DCL avatar bone names to VRM 0.x humanoid bone names.
 //
@@ -317,8 +317,13 @@ function stripAnimations(json: any): void {
  * Undoes the display-only emissive gain (see applyUnityEmissiveGain) before writing the
  * file. The serializer reads the live scene, so without this the export would carry
  * emissiveFactor values above the [0,1] range the glTF spec allows.
+ *
+ * Guarded by isUnityToneMappingEnabled: when the escape hatch (?toneMapping=none) is active,
+ * applyUnityEmissiveGain is a no-op, so there is nothing to undo — dividing un-scaled values
+ * by 12.5 would silently crush the emissive to near-zero in the exported file.
  */
 export function normalizeEmissiveForExport(json: any): void {
+  if (!isUnityToneMappingEnabled()) return
   if (!Array.isArray(json.materials)) return
 
   for (const mat of json.materials) {

--- a/src/lib/babylon/export.ts
+++ b/src/lib/babylon/export.ts
@@ -1,5 +1,6 @@
 import { AbstractMesh, Bone, Matrix, Quaternion, Scene, Skeleton, TransformNode, Vector3 } from '@babylonjs/core'
 import { GLTF2Export } from '@babylonjs/serializers/glTF'
+import { UNITY_EMISSIVE_GAIN } from './emissive'
 
 // Maps DCL avatar bone names to VRM 0.x humanoid bone names.
 //
@@ -313,6 +314,22 @@ function stripAnimations(json: any): void {
 }
 
 /**
+ * Undoes the display-only emissive gain (see applyUnityEmissiveGain) before writing the
+ * file. The serializer reads the live scene, so without this the export would carry
+ * emissiveFactor values above the [0,1] range the glTF spec allows.
+ */
+export function normalizeEmissiveForExport(json: any): void {
+  if (!Array.isArray(json.materials)) return
+
+  for (const mat of json.materials) {
+    if (!Array.isArray(mat.emissiveFactor)) continue
+    mat.emissiveFactor = mat.emissiveFactor.map((channel: number) =>
+      Math.min(1, Math.max(0, channel / UNITY_EMISSIVE_GAIN)),
+    )
+  }
+}
+
+/**
  * Tags every material as KHR_materials_unlit so VRM viewers render the avatar
  * with the flat / cartoon look DCL uses, instead of PBR metallic shading.
  * Matches the juanma reference, which also marks every material as unlit.
@@ -560,6 +577,7 @@ export async function exportVRM(scene: Scene): Promise<Blob> {
     mergeSkeletons(json)
     restructureForVrm(json)
     stripAnimations(json)
+    normalizeEmissiveForExport(json)
     applyUnlitMaterials(json)
     injectVRMExtension(json)
 

--- a/src/lib/babylon/scene.ts
+++ b/src/lib/babylon/scene.ts
@@ -11,8 +11,10 @@ import {
   Engine,
   GlowLayer,
   HemisphericLight,
+  ImageProcessingConfiguration,
   Mesh,
   MeshBuilder,
+  PBRMaterial,
   Scene,
   SceneLoader,
   Sound,
@@ -36,6 +38,7 @@ import {
   WearableDefinition,
 } from '@dcl/schemas'
 import { hexToColor } from './utils'
+import { getOriginalEmissiveColor, getToneMappingExposure, isUnityToneMappingEnabled } from './emissive'
 import { isIOs } from '../env'
 import { getWearableRepresentation } from '../representation'
 import { createSceneController } from '../scene'
@@ -116,6 +119,16 @@ export async function createScene(
     : hexToColor(config.background.color).toColor4()
   root.ambientColor = new Color3(1, 1, 1)
   root.preventDefaultOnPointerDown = false
+
+  // Wearables carry emissive values authored against Unity's ACES tonemapper (see
+  // applyUnityEmissiveGain). Set on the scene rather than through a DefaultRenderingPipeline
+  // so it runs inside the material shaders: Tools.CreateScreenshotUsingRenderTarget renders
+  // to its own target and would skip a camera post-process, leaving screenshots untonemapped.
+  if (isUnityToneMappingEnabled()) {
+    root.imageProcessingConfiguration.toneMappingEnabled = true
+    root.imageProcessingConfiguration.toneMappingType = ImageProcessingConfiguration.TONEMAPPING_ACES
+    root.imageProcessingConfiguration.exposure = getToneMappingExposure()
+  }
 
   if (config.showSceneBoundaries) {
     // create transparent cylinder to show the boundaries
@@ -235,6 +248,22 @@ export async function createScene(
   if (!isIOs()) {
     const glowLayer = new GlowLayer('glow', root)
     glowLayer.intensity = 2.0
+    // Feed the glow the pre-gain emissive so the bleed stays what it was before
+    // applyUnityEmissiveGain; otherwise every emissive wearable glows 12.5x harder.
+    // Mirrors Babylon's own default selector, only swapping in the unscaled color.
+    glowLayer.customEmissiveColorSelector = (_mesh, _subMesh, material, result) => {
+      const emissive =
+        material instanceof PBRMaterial
+          ? getOriginalEmissiveColor(material)
+          : (material as StandardMaterial).emissiveColor
+      if (!emissive) {
+        const { r, g, b, a } = glowLayer.neutralColor
+        result.set(r, g, b, a)
+        return
+      }
+      const level = (material as PBRMaterial | StandardMaterial).emissiveTexture?.level ?? 1
+      result.set(emissive.r * level, emissive.g * level, emissive.b * level, material.alpha)
+    }
   }
 
   // Render loop

--- a/src/lib/babylon/scene.ts
+++ b/src/lib/babylon/scene.ts
@@ -255,7 +255,9 @@ export async function createScene(
       const emissive =
         material instanceof PBRMaterial
           ? getOriginalEmissiveColor(material)
-          : (material as StandardMaterial).emissiveColor
+          : material instanceof StandardMaterial
+            ? material.emissiveColor
+            : undefined
       if (!emissive) {
         const { r, g, b, a } = glowLayer.neutralColor
         result.set(r, g, b, a)

--- a/src/lib/babylon/test-helpers.ts
+++ b/src/lib/babylon/test-helpers.ts
@@ -1,0 +1,17 @@
+import { afterEach } from 'vitest'
+
+/**
+ * Sets the URL search string for the current window. Used by tests that exercise
+ * URL-driven escape hatches (?toneMapping=none, ?culling=none, ?exposure=…).
+ */
+export function setSearch(search: string): void {
+  window.history.replaceState({}, '', `/${search}`)
+}
+
+/**
+ * Registers an afterEach hook that resets the URL search string so one test's
+ * query params don't leak into the next.
+ */
+export function cleanupSearchAfterEach(): void {
+  afterEach(() => setSearch(''))
+}

--- a/src/lib/babylon/wearable.ts
+++ b/src/lib/babylon/wearable.ts
@@ -10,6 +10,8 @@
 import { Color3, PBRMaterial, Scene } from '@babylonjs/core'
 import { WearableDefinition, BodyShape } from '@dcl/schemas'
 import { getWearableRepresentation, isTexture, getContentUrl } from '../representation'
+import { applyUnityBackFaceCulling } from './culling'
+import { applyUnityEmissiveGain } from './emissive'
 import { loadAssetContainer } from './scene'
 import './toon'
 
@@ -37,6 +39,9 @@ export async function loadWearable(
 
   // Clean up
   for (const originalMaterial of container.materials) {
+    // Not PBR-specific: Unity culls back faces on every material it generates.
+    applyUnityBackFaceCulling(originalMaterial)
+
     if (originalMaterial instanceof PBRMaterial) {
       const newMaterial = originalMaterial as PBRMaterial
 
@@ -46,6 +51,8 @@ export async function loadWearable(
         newMaterial.metallic = 0
         newMaterial.metallicF0Factor = 0
       }
+
+      applyUnityEmissiveGain(newMaterial)
 
       if (newMaterial.name.toLowerCase().includes('hair')) {
         if (hair) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,5 +13,9 @@ export default defineConfig(({ command, mode }) => {
       },
     },
     ...(command === 'build' ? { base: envVariables.VITE_BASE_URL } : undefined),
+    test: {
+      environment: 'jsdom',
+      include: ['src/**/*.test.ts'],
+    },
   }
 })


### PR DESCRIPTION
## Problem

Wearables with a non-zero `emissiveFactor` render very differently in the Babylon preview than in the Unity preview, which is the reference look.

Repro — toggle `unity` true/false:

https://wearable-preview.decentraland.org/?contract=0x65ed61c4fc2d1102ed574a48e664b90b7a300ea8&item=0&disableBackground=true&unity=true&mode=marketplace

`Hell's Angels` isolates it cleanly, because its two materials differ only in emissive:

| material | baseColorTexture | emissiveFactor | Unity vs Babylon |
| --- | --- | --- | --- |
| `Material.001` (feathers) | `Fire2.jpg` | `[0.4812, 0, 0.0036]` | **diverges** |
| `Material.002` (inner) | black→red gradient | `[0, 0, 0]` | matches |

Unity showed flat pale cream feathers with the fire texture invisible; Babylon showed saturated fire red. Separately, Babylon drew the full feather fan from both front and back, where Unity shows a subset from the front.

## Cause

**Unity amplifies `emissiveFactor` by 12.5 and tonemaps the result:**

- `ToonMaterialGenerator.cs:12,55` — `_Emissive_Color = gltfMaterial.Emissive * 5`
- `DCL_ToonBodyDoubleShadeWithFeather.hlsl:382` — `* 2.5f` again; `_Emissive_Tex` defaults to `"white"` so it passes through at 1.0
- `URP_GlobalVolumeProfile.asset` applies **ACES** (`Tonemapping.mode: 2`)

Net `0.4812 → 6.02` linear red. ACES walks a very bright saturated red up the red→orange→white path and desaturates it, swamping the base texture — hence flat cream.

**Babylon applied the factor 1:1 with no tonemapping**, so it simply clamped to saturated red. Nothing in `src/` ever set `toneMappingEnabled`.

**Culling:** `ToonMaterialGenerator.cs:95` hardcodes `CullMode.Back` for every material, ignoring the glTF `doubleSided` flag. Babylon honours it, so every flat feather card drew twice.

## Fix

- **`emissive.ts`** — applies the ×12.5 gain, keeping the two Unity multipliers as separately named constants so the link back to `aang-renderer` stays traceable. Idempotent, since option updates re-render.
- **`scene.ts`** — ACES via `scene.imageProcessingConfiguration`, **not** a `DefaultRenderingPipeline`. `CreateScreenshotUsingRenderTarget` renders to its own target and skips camera post-processes, so a pipeline would tonemap the live canvas but not the screenshots the shop consumes. Scene-level image processing runs inside the material shaders and survives that path. It also avoids adding RTTs that would inflate `getMetrics()`.
- **Exposure lift (not in the original plan, turned out to be required)** — ACES expects HDR headroom this scene lacks. Plain ACES made the *non-emissive* material worse than before:

  | | feathers (emissive) | inner (non-emissive) |
  | --- | --- | --- |
  | Unity (target) | `#FBE9BA` | `#751610` |
  | before | `#F6AD9E` | `#982218` |
  | ACES, exposure 1 | `#EFAD86` | `#400E0A` ← worse |
  | ACES, exposure 2 | `#F9D2AF` | `#6D150F` |

  The default started at 2.0 (conventional ACES LDR compensation), but a catalogue-wide sweep over 10 marketplace wearables showed 2.0 was too bright — most items ended up *further* from Unity than master. **The shipped default is now 1.2**, which sits in the optimal basin (1.1–1.3) on both mean-abs-error and per-pixel-delta metrics. See `docs/emissive-tonemapping-parity.md` for the full measurement table. Overridable via `?exposure=N` for QA sweeps.

- **Glow layer** — fed the pre-gain emissive via `customEmissiveColorSelector`, so bleed is unchanged rather than 12.5× stronger.
- **`culling.ts`** — forces `backFaceCulling`, applied outside the `instanceof PBRMaterial` branch because Unity culls every material it generates. Subject coverage: front 88707 → 61983 px, back 115874 → 88125 px.
- **`normalizeEmissiveForExport`** — `exportVRM` runs `GLTF2Export` over the live scene, so without this the export would carry `emissiveFactor: 6.01`, outside the glTF-spec `[0,1]` range. Guarded by `isUnityToneMappingEnabled()` so the `?toneMapping=none` escape hatch does not crush un-scaled values.

Both behaviours are independently reversible via `?toneMapping=none` and `?culling=none` — separate switches, because the culling change overrides what the asset file itself declares.

## Tests

`npm test` was already broken: jest was declared in `package.json` but never installed. Replaced with **vitest**, which reuses `vite.config.ts` and needs no extra transform config.

**22 tests, all passing** — gain value/zero-case/idempotency/metadata preservation, exposure default and `?exposure=` override, culling override, both escape hatches, and export normalization including clamping (including the `toneMapping=none` guard).

Typecheck clean on all touched files (5 pre-existing errors elsewhere, unchanged). Prettier clean on new files.

## Known gaps

All documented in `docs/emissive-tonemapping-parity.md`:

- **Bloom / HDR compositing deferred.** Unity's bloom (threshold 1, intensity 1) pushes highlights further toward white than a tonemapper alone can. Doing it properly needs `getScreenshot` migrated off `CreateScreenshotUsingRenderTarget` first.
- **Catalogue-wide by nature.** The culling change may reveal holes anywhere authors relied on double-sided geometry — hair cards, skirts, capes are the likely candidates.

## Screenshots

<img width="1393" height="540" alt="image" src="https://github.com/user-attachments/assets/e3dd5af7-319e-46cc-bc04-521812c5c99a" />

<img width="1395" height="530" alt="image" src="https://github.com/user-attachments/assets/78e369a7-f1b3-4be4-bdc6-2e2df0d0c3dd" />
<img width="1141" height="440" alt="image" src="https://github.com/user-attachments/assets/8438e60a-3017-420f-ae49-542705a77e18" />
<img width="1148" height="437" alt="image" src="https://github.com/user-attachments/assets/ba92bdf7-d045-4fe4-9555-3757cb3aa41a" />

