### PR TITLE
fix: keep spring bones at rest until something moves them

### DIFF
--- a/src/lib/babylon/springBones.ts
+++ b/src/lib/babylon/springBones.ts
@@ -20,8 +20,15 @@ const DEFAULT_PARAMS: SpringBoneParams = {
   drag: 0.5,
 }
 
+type RestPose = {
+  rot: Quaternion
+  pos: Vector3
+  scale: Vector3
+}
+
 type SpringJointState = {
   node: TransformNode
+  childNode: TransformNode
   initialLocalRotation: Quaternion
   initialLocalMatrix: Matrix
   boneAxis: Vector3
@@ -35,6 +42,9 @@ type SpringChain = {
   joints: SpringJointState[]
   params: SpringBoneParams
   centerNode: TransformNode | null
+  // World-space state (tails, bone lengths) is seeded on the first simulated frame instead of
+  // here: the scene is still rescaled and repositioned by center() after the chains are built.
+  seeded: boolean
 }
 
 function isSpringBoneName(name: string): boolean {
@@ -116,9 +126,13 @@ function resolveCenter(centerName: string | undefined, scene: Scene): TransformN
   return null
 }
 
-function buildChain(root: TransformNode, scene: Scene, params: SpringBoneParams): SpringChain | null {
+function buildChain(
+  root: TransformNode,
+  scene: Scene,
+  params: SpringBoneParams,
+  restPoses: Map<TransformNode, RestPose>,
+): SpringChain | null {
   const centerNode = resolveCenter(params.center, scene)
-  const worldToCenter = centerNode ? Matrix.Invert(centerNode.getWorldMatrix()) : Matrix.Identity()
 
   // Collect chain nodes depth-first (linear chain), capped to prevent DoS
   const chainNodes: TransformNode[] = [root]
@@ -139,46 +153,73 @@ function buildChain(root: TransformNode, scene: Scene, params: SpringBoneParams)
     const node = chainNodes[i]
     const childNode = chainNodes[i + 1]
 
-    node.computeWorldMatrix(true)
-    childNode.computeWorldMatrix(true)
-
     // Ensure quaternion rotation mode
     if (!node.rotationQuaternion) {
       node.rotationQuaternion = Quaternion.FromEulerVector(node.rotation)
     }
 
-    const initialLocalRotation = node.rotationQuaternion.clone()
+    // Rest pose comes from the load-time snapshot, not from the live transform: a chain built
+    // while an animation is playing would otherwise take that animated frame as its rest pose.
+    const rest = restPoses.get(node)
+    const childRest = restPoses.get(childNode)
 
-    // Compute local matrix from current local transform
-    const initialLocalMatrix = Matrix.Compose(node.scaling, initialLocalRotation, node.position)
+    const initialLocalRotation = (rest?.rot ?? node.rotationQuaternion).clone()
+    const initialLocalMatrix = Matrix.Compose(
+      rest?.scale ?? node.scaling,
+      initialLocalRotation,
+      rest?.pos ?? node.position,
+    )
 
     // Bone axis: direction from node to child in local space
-    const nodeWorldMatrix = node.getWorldMatrix()
-    const nodeWorldPos = node.getAbsolutePosition()
-    const childWorldPos = childNode.getAbsolutePosition()
-
-    const boneLength = Vector3.Distance(nodeWorldPos, childWorldPos)
-
-    // Compute local direction to child
-    const nodeWorldMatrixInv = Matrix.Invert(nodeWorldMatrix)
-    const childLocalPos = Vector3.TransformCoordinates(childWorldPos, nodeWorldMatrixInv)
+    const childLocalPos = (childRest?.pos ?? childNode.position).clone()
     const boneAxis = childLocalPos.length() > 0 ? childLocalPos.normalize() : new Vector3(0, 1, 0)
-
-    // Initialize tail positions in center space
-    const currentTail = Vector3.TransformCoordinates(childWorldPos, worldToCenter)
 
     joints.push({
       node,
+      childNode,
       initialLocalRotation,
       initialLocalMatrix,
       boneAxis,
-      boneLength,
-      currentTail: currentTail.clone(),
-      previousTail: currentTail.clone(),
+      boneLength: 0,
+      currentTail: new Vector3(),
+      previousTail: new Vector3(),
     })
   }
 
-  return { rootName: root.name, joints, params, centerNode }
+  return { rootName: root.name, joints, params, centerNode, seeded: false }
+}
+
+/**
+ * Puts the tail where the rest pose points, with zero velocity, so the joint starts quiet
+ * instead of springing from a stale position.
+ */
+function seedJointToRest(joint: SpringJointState, worldPos: Vector3, restMatrix: Matrix, worldToCenter: Matrix): void {
+  Vector3.TransformNormalToRef(joint.boneAxis, restMatrix, _scratchVec3C)
+  const len = _scratchVec3C.length()
+  if (len > 0) _scratchVec3C.scaleInPlace(1 / len)
+  _scratchVec3C.scaleInPlace(joint.boneLength)
+  worldPos.addToRef(_scratchVec3C, _scratchVec3D)
+  Vector3.TransformCoordinatesToRef(_scratchVec3D, worldToCenter, joint.currentTail)
+  joint.previousTail.copyFrom(joint.currentTail)
+  // rotationQuaternion is guaranteed non-null: buildChain sets it during init
+  joint.node.rotationQuaternion!.copyFrom(joint.initialLocalRotation)
+}
+
+function seedChainToRest(chain: SpringChain, worldToCenter: Matrix): void {
+  for (const joint of chain.joints) {
+    joint.node.computeWorldMatrix(true)
+    joint.childNode.computeWorldMatrix(true)
+
+    const worldPos = joint.node.getAbsolutePosition()
+    // Measured here rather than at build time so it reflects the final world scale
+    joint.boneLength = Vector3.Distance(worldPos, joint.childNode.getAbsolutePosition())
+
+    const parentWorldMatrix =
+      joint.node.parent instanceof TransformNode ? joint.node.parent.getWorldMatrix() : _identityMatrix
+    joint.initialLocalMatrix.multiplyToRef(parentWorldMatrix, _scratchMatrixB)
+
+    seedJointToRest(joint, worldPos, _scratchMatrixB, worldToCenter)
+  }
 }
 
 function updateSimulation(chains: SpringChain[], scene: Scene): void {
@@ -199,6 +240,12 @@ function updateSimulation(chains: SpringChain[], scene: Scene): void {
     } else {
       worldToCenter = _identityMatrix
       centerToWorld = _identityMatrix
+    }
+
+    if (!chain.seeded) {
+      seedChainToRest(chain, worldToCenter)
+      chain.seeded = true
+      continue
     }
 
     // Normalize gravityDir (guard against zero vector)
@@ -293,15 +340,7 @@ function updateSimulation(chains: SpringChain[], scene: Scene): void {
 
       // 7. NaN/Infinity recovery: if tail state is corrupted, reset to rest pose
       if (!isFiniteVec3(joint.currentTail) || !isFiniteVec3(joint.previousTail)) {
-        // Recompute rest tail position in center space as recovery
-        Vector3.TransformNormalToRef(joint.boneAxis, _scratchMatrixB, _scratchVec3C)
-        const rLen = _scratchVec3C.length()
-        if (rLen > 0) _scratchVec3C.scaleInPlace(1 / rLen)
-        _scratchVec3C.scaleInPlace(joint.boneLength)
-        worldPos.addToRef(_scratchVec3C, _scratchVec3D)
-        Vector3.TransformCoordinatesToRef(_scratchVec3D, worldToCenter, joint.currentTail)
-        joint.previousTail.copyFrom(joint.currentTail)
-        joint.node.rotationQuaternion!.copyFrom(joint.initialLocalRotation)
+        seedJointToRest(joint, worldPos, _scratchMatrixB, worldToCenter)
       }
 
       // Force world matrix update for children
@@ -317,6 +356,7 @@ function isFiniteVec3(v: Vector3): boolean {
 export class SpringBoneSimulation {
   private wearables = new Map<string, SpringChain[]>()
   private containers = new Map<string, AssetContainer>()
+  private restPoses = new Map<TransformNode, RestPose>()
   private beforeRenderCallback: (() => void) | null = null
   private scene: Scene | null = null
 
@@ -328,8 +368,18 @@ export class SpringBoneSimulation {
   ): void {
     this.scene = scene
     this.containers.set(itemId, container)
-    const chains: SpringChain[] = []
 
+    // Snapshot the rest pose while the wearable is still unanimated, so chains built later
+    // (updateParams, mid-emote) get the authored pose rather than the current animated one
+    for (const node of container.transformNodes) {
+      this.restPoses.set(node, {
+        rot: node.rotationQuaternion ? node.rotationQuaternion.clone() : Quaternion.FromEulerVector(node.rotation),
+        pos: node.position.clone(),
+        scale: node.scaling.clone(),
+      })
+    }
+
+    const chains: SpringChain[] = []
     if (springBonesParams) {
       for (const node of container.transformNodes) {
         if (!isSpringBoneName(node.name)) continue
@@ -337,7 +387,7 @@ export class SpringBoneSimulation {
         const params = springBonesParams[node.name]
         if (!params) continue
 
-        const chain = buildChain(node, scene, validateParams(params))
+        const chain = buildChain(node, scene, validateParams(params), this.restPoses)
         if (chain) {
           chains.push(chain)
           if (chains.length >= MAX_CHAINS_PER_WEARABLE) break
@@ -379,11 +429,6 @@ export class SpringBoneSimulation {
     // NOTE: Unlike registerWearable(), we intentionally skip isSpringBoneName()
     // checks here. This method is the editor's mechanism for
     // dynamically adding spring bones to arbitrary nodes via external params.
-    // KNOWN LIMITATION: buildChain() captures the current pose as the rest pose.
-    // If an animation is playing, the "rest" will be the current animated position,
-    // not the bind/T-pose. This can cause visual artifacts where the spring bone
-    // springs from the wrong base orientation. A full preview reload (save) does not
-    // have this issue because chains are built before animation starts.
     const container = this.containers.get(itemId)
     if (this.scene && container) {
       const existingNames = new Set(chains?.map((c) => c.rootName) ?? [])
@@ -395,7 +440,7 @@ export class SpringBoneSimulation {
         const node = container.transformNodes.find((n) => n.name === boneName)
         if (!node) continue
 
-        const chain = buildChain(node, this.scene, validateParams(boneParams))
+        const chain = buildChain(node, this.scene, validateParams(boneParams), this.restPoses)
         if (chain) {
           if (!chains) {
             chains = []
@@ -427,6 +472,7 @@ export class SpringBoneSimulation {
     }
     this.wearables.clear()
     this.containers.clear()
+    this.restPoses.clear()
     this.scene = null
   }
 }

--- a/src/lib/babylon/springBones.ts
+++ b/src/lib/babylon/springBones.ts
@@ -186,23 +186,14 @@ function seedJointToRest(joint: SpringJointState, worldPos: Vector3, restMatrix:
 }
 
 /**
- * Recomputes a node's world matrix along with every ancestor's, top down.
- *
- * `computeWorldMatrix(true)` only forces the node itself: it pulls ancestors in through
- * `getWorldMatrix()`, which returns a matrix cached per render id. The simulation runs in
- * beforeRender, before the scene advances that id, so an ancestor moved since the last frame
- * -- center() reparenting and rescaling the whole avatar -- still reports its old transform.
+ * Recomputes a node's world matrix and every ancestor's, top down. `computeWorldMatrix(true)`
+ * forces only the node it is called on: ancestors come in through `getWorldMatrix()`, which
+ * serves a matrix cached per render id, and the scene advances that id after beforeRender. So an
+ * ancestor moved since the last frame -- center() rescaling the avatar -- reports its old one.
  */
 function refreshWorldMatrix(node: TransformNode): void {
-  const ancestors: TransformNode[] = []
-  let current: TransformNode | null = node
-  while (current) {
-    ancestors.push(current)
-    current = current.parent instanceof TransformNode ? current.parent : null
-  }
-  for (let i = ancestors.length - 1; i >= 0; i--) {
-    ancestors[i].computeWorldMatrix(true)
-  }
+  if (node.parent instanceof TransformNode) refreshWorldMatrix(node.parent)
+  node.computeWorldMatrix(true)
 }
 
 function seedChainToRest(chain: SpringChain, worldToCenter: Matrix): void {
@@ -446,25 +437,19 @@ export class SpringBoneSimulation {
     }
   }
 
-  /**
-   * Drops the world-space state of every chain so it re-seeds on the next simulated frame.
-   */
-  private unseedAll = (): void => {
-    for (const chains of this.wearables.values()) {
-      for (const chain of chains) {
-        chain.seeded = false
-      }
-    }
-  }
-
   start(scene: Scene): void {
     if (this.beforeRenderCallback) return
     this.scene = scene
 
     // Starting an animation teleports the rig from its bind pose to the animation's first frame.
     // Re-seed after that jump, otherwise the springs read it as velocity and swing into place.
+    const unseedAll = () => {
+      for (const chains of this.wearables.values()) {
+        for (const chain of chains) chain.seeded = false
+      }
+    }
     for (const group of scene.animationGroups) {
-      group.onAnimationGroupPlayObservable.add(this.unseedAll)
+      group.onAnimationGroupPlayObservable.add(unseedAll)
     }
 
     this.beforeRenderCallback = () => {

--- a/src/lib/babylon/springBones.ts
+++ b/src/lib/babylon/springBones.ts
@@ -56,10 +56,8 @@ const _scratchMatrixB = new Matrix()
 const _scratchMatrixC = new Matrix()
 const _scratchQuat = new Quaternion()
 const _quatScratchVec3 = new Vector3()
+// Read-only: never pass as the output ref of a *ToRef call
 const _identityMatrix = Matrix.Identity()
-// Freeze internal data to prevent accidental mutation via *ToRef calls
-const _identityData = (_identityMatrix as unknown as Record<string, unknown>)['_m']
-if (_identityData instanceof Float32Array) Object.freeze(_identityData)
 
 function quaternionFromUnitVectorsToRef(from: Vector3, to: Vector3, result: Quaternion): void {
   const dot = Vector3.Dot(from, to)

--- a/src/lib/babylon/springBones.ts
+++ b/src/lib/babylon/springBones.ts
@@ -452,9 +452,26 @@ export class SpringBoneSimulation {
     }
   }
 
+  /**
+   * Drops the world-space state of every chain so it re-seeds on the next simulated frame.
+   */
+  private unseedAll = (): void => {
+    for (const chains of this.wearables.values()) {
+      for (const chain of chains) {
+        chain.seeded = false
+      }
+    }
+  }
+
   start(scene: Scene): void {
     if (this.beforeRenderCallback) return
     this.scene = scene
+
+    // Starting an animation teleports the rig from its bind pose to the animation's first frame.
+    // Re-seed after that jump, otherwise the springs read it as velocity and swing into place.
+    for (const group of scene.animationGroups) {
+      group.onAnimationGroupPlayObservable.add(this.unseedAll)
+    }
 
     this.beforeRenderCallback = () => {
       for (const chains of this.wearables.values()) {

--- a/src/lib/babylon/springBones.ts
+++ b/src/lib/babylon/springBones.ts
@@ -20,12 +20,6 @@ const DEFAULT_PARAMS: SpringBoneParams = {
   drag: 0.5,
 }
 
-type RestPose = {
-  rot: Quaternion
-  pos: Vector3
-  scale: Vector3
-}
-
 type SpringJointState = {
   node: TransformNode
   childNode: TransformNode
@@ -126,12 +120,7 @@ function resolveCenter(centerName: string | undefined, scene: Scene): TransformN
   return null
 }
 
-function buildChain(
-  root: TransformNode,
-  scene: Scene,
-  params: SpringBoneParams,
-  restPoses: Map<TransformNode, RestPose>,
-): SpringChain | null {
+function buildChain(root: TransformNode, scene: Scene, params: SpringBoneParams): SpringChain | null {
   const centerNode = resolveCenter(params.center, scene)
 
   // Collect chain nodes depth-first (linear chain), capped to prevent DoS
@@ -158,20 +147,11 @@ function buildChain(
       node.rotationQuaternion = Quaternion.FromEulerVector(node.rotation)
     }
 
-    // Rest pose comes from the load-time snapshot, not from the live transform: a chain built
-    // while an animation is playing would otherwise take that animated frame as its rest pose.
-    const rest = restPoses.get(node)
-    const childRest = restPoses.get(childNode)
-
-    const initialLocalRotation = (rest?.rot ?? node.rotationQuaternion).clone()
-    const initialLocalMatrix = Matrix.Compose(
-      rest?.scale ?? node.scaling,
-      initialLocalRotation,
-      rest?.pos ?? node.position,
-    )
+    const initialLocalRotation = node.rotationQuaternion.clone()
+    const initialLocalMatrix = Matrix.Compose(node.scaling, initialLocalRotation, node.position)
 
     // Bone axis: direction from node to child in local space
-    const childLocalPos = (childRest?.pos ?? childNode.position).clone()
+    const childLocalPos = childNode.position.clone()
     const boneAxis = childLocalPos.length() > 0 ? childLocalPos.normalize() : new Vector3(0, 1, 0)
 
     joints.push({
@@ -376,7 +356,6 @@ function isFiniteVec3(v: Vector3): boolean {
 export class SpringBoneSimulation {
   private wearables = new Map<string, SpringChain[]>()
   private containers = new Map<string, AssetContainer>()
-  private restPoses = new Map<TransformNode, RestPose>()
   private beforeRenderCallback: (() => void) | null = null
   private scene: Scene | null = null
 
@@ -388,18 +367,8 @@ export class SpringBoneSimulation {
   ): void {
     this.scene = scene
     this.containers.set(itemId, container)
-
-    // Snapshot the rest pose while the wearable is still unanimated, so chains built later
-    // (updateParams, mid-emote) get the authored pose rather than the current animated one
-    for (const node of container.transformNodes) {
-      this.restPoses.set(node, {
-        rot: node.rotationQuaternion ? node.rotationQuaternion.clone() : Quaternion.FromEulerVector(node.rotation),
-        pos: node.position.clone(),
-        scale: node.scaling.clone(),
-      })
-    }
-
     const chains: SpringChain[] = []
+
     if (springBonesParams) {
       for (const node of container.transformNodes) {
         if (!isSpringBoneName(node.name)) continue
@@ -407,7 +376,7 @@ export class SpringBoneSimulation {
         const params = springBonesParams[node.name]
         if (!params) continue
 
-        const chain = buildChain(node, scene, validateParams(params), this.restPoses)
+        const chain = buildChain(node, scene, validateParams(params))
         if (chain) {
           chains.push(chain)
           if (chains.length >= MAX_CHAINS_PER_WEARABLE) break
@@ -449,6 +418,11 @@ export class SpringBoneSimulation {
     // NOTE: Unlike registerWearable(), we intentionally skip isSpringBoneName()
     // checks here. This method is the editor's mechanism for
     // dynamically adding spring bones to arbitrary nodes via external params.
+    // KNOWN LIMITATION: buildChain() captures the current pose as the rest pose.
+    // If an animation is playing, the "rest" will be the current animated position,
+    // not the bind/T-pose. This can cause visual artifacts where the spring bone
+    // springs from the wrong base orientation. A full preview reload (save) does not
+    // have this issue because chains are built before animation starts.
     const container = this.containers.get(itemId)
     if (this.scene && container) {
       const existingNames = new Set(chains?.map((c) => c.rootName) ?? [])
@@ -460,7 +434,7 @@ export class SpringBoneSimulation {
         const node = container.transformNodes.find((n) => n.name === boneName)
         if (!node) continue
 
-        const chain = buildChain(node, this.scene, validateParams(boneParams), this.restPoses)
+        const chain = buildChain(node, this.scene, validateParams(boneParams))
         if (chain) {
           if (!chains) {
             chains = []
@@ -509,7 +483,6 @@ export class SpringBoneSimulation {
     }
     this.wearables.clear()
     this.containers.clear()
-    this.restPoses.clear()
     this.scene = null
   }
 }

--- a/src/lib/babylon/springBones.ts
+++ b/src/lib/babylon/springBones.ts
@@ -205,9 +205,29 @@ function seedJointToRest(joint: SpringJointState, worldPos: Vector3, restMatrix:
   joint.node.rotationQuaternion!.copyFrom(joint.initialLocalRotation)
 }
 
+/**
+ * Recomputes a node's world matrix along with every ancestor's, top down.
+ *
+ * `computeWorldMatrix(true)` only forces the node itself: it pulls ancestors in through
+ * `getWorldMatrix()`, which returns a matrix cached per render id. The simulation runs in
+ * beforeRender, before the scene advances that id, so an ancestor moved since the last frame
+ * -- center() reparenting and rescaling the whole avatar -- still reports its old transform.
+ */
+function refreshWorldMatrix(node: TransformNode): void {
+  const ancestors: TransformNode[] = []
+  let current: TransformNode | null = node
+  while (current) {
+    ancestors.push(current)
+    current = current.parent instanceof TransformNode ? current.parent : null
+  }
+  for (let i = ancestors.length - 1; i >= 0; i--) {
+    ancestors[i].computeWorldMatrix(true)
+  }
+}
+
 function seedChainToRest(chain: SpringChain, worldToCenter: Matrix): void {
   for (const joint of chain.joints) {
-    joint.node.computeWorldMatrix(true)
+    refreshWorldMatrix(joint.node)
     joint.childNode.computeWorldMatrix(true)
 
     const worldPos = joint.node.getAbsolutePosition()

--- a/src/lib/babylon/springBones.ts
+++ b/src/lib/babylon/springBones.ts
@@ -55,7 +55,11 @@ const _scratchMatrix = new Matrix()
 const _scratchMatrixB = new Matrix()
 const _scratchMatrixC = new Matrix()
 const _scratchQuat = new Quaternion()
+const _quatScratchVec3 = new Vector3()
 const _identityMatrix = Matrix.Identity()
+// Freeze internal data to prevent accidental mutation via *ToRef calls
+const _identityData = (_identityMatrix as unknown as Record<string, unknown>)['_m']
+if (_identityData instanceof Float32Array) Object.freeze(_identityData)
 
 function quaternionFromUnitVectorsToRef(from: Vector3, to: Vector3, result: Quaternion): void {
   const dot = Vector3.Dot(from, to)
@@ -64,16 +68,16 @@ function quaternionFromUnitVectorsToRef(from: Vector3, to: Vector3, result: Quat
     return
   }
   if (dot < -0.999999) {
-    Vector3.CrossToRef(Vector3.Right(), from, _scratchVec3E)
-    if (_scratchVec3E.lengthSquared() < 0.000001) {
-      Vector3.CrossToRef(Vector3.Up(), from, _scratchVec3E)
+    Vector3.CrossToRef(Vector3.Right(), from, _quatScratchVec3)
+    if (_quatScratchVec3.lengthSquared() < 0.000001) {
+      Vector3.CrossToRef(Vector3.Up(), from, _quatScratchVec3)
     }
-    _scratchVec3E.normalize()
-    Quaternion.RotationAxisToRef(_scratchVec3E, Math.PI, result)
+    _quatScratchVec3.normalize()
+    Quaternion.RotationAxisToRef(_quatScratchVec3, Math.PI, result)
     return
   }
-  Vector3.CrossToRef(from, to, _scratchVec3E)
-  result.set(_scratchVec3E.x, _scratchVec3E.y, _scratchVec3E.z, 1 + dot)
+  Vector3.CrossToRef(from, to, _quatScratchVec3)
+  result.set(_quatScratchVec3.x, _quatScratchVec3.y, _quatScratchVec3.z, 1 + dot)
   result.normalize()
 }
 
@@ -348,6 +352,7 @@ export class SpringBoneSimulation {
   private wearables = new Map<string, SpringChain[]>()
   private containers = new Map<string, AssetContainer>()
   private beforeRenderCallback: (() => void) | null = null
+  private observerCleanups: (() => void)[] = []
   private scene: Scene | null = null
 
   registerWearable(
@@ -448,11 +453,20 @@ export class SpringBoneSimulation {
         for (const chain of chains) chain.seeded = false
       }
     }
-    for (const group of scene.animationGroups) {
-      group.onAnimationGroupPlayObservable.add(unseedAll)
+    // Track which groups have been hooked so late-added groups get covered too
+    const hookedGroups = new Set<unknown>()
+    const hookNewGroups = () => {
+      for (const group of scene.animationGroups) {
+        if (hookedGroups.has(group)) continue
+        hookedGroups.add(group)
+        const observer = group.onAnimationGroupPlayObservable.add(unseedAll)
+        if (observer) this.observerCleanups.push(() => group.onAnimationGroupPlayObservable.remove(observer))
+      }
     }
+    hookNewGroups()
 
     this.beforeRenderCallback = () => {
+      hookNewGroups()
       for (const chains of this.wearables.values()) {
         updateSimulation(chains, scene)
       }
@@ -466,6 +480,8 @@ export class SpringBoneSimulation {
       scene.unregisterBeforeRender(this.beforeRenderCallback)
       this.beforeRenderCallback = null
     }
+    for (const cleanup of this.observerCleanups) cleanup()
+    this.observerCleanups.length = 0
     this.wearables.clear()
     this.containers.clear()
     this.scene = null


### PR DESCRIPTION
## Problem

Wearables with spring bones — most base hairs (`punk`, `rasta`, `Double Bun`, `Two Tails`, …) — swing into place from a wrong orientation for the first ~1–2 seconds of a Babylon preview. The hair should hang still and only move once something moves it.

Repro:

```
/?profile=default&urn=urn:decentraland:off-chain:base-avatars:punk&bodyShape=male
```

Measured peak deflection from rest on the affected frames: **172–173°** — the mohawk fully inverts, then rings for ~70 frames because base hairs ship `drag: 0`.

## Cause

**A stale world-matrix cache.** Babylon caches each node's world matrix per render id and recomputes only when that id changes. `computeWorldMatrix(true)` forces the node it is called on, but that node pulls its ancestors in through `getWorldMatrix()`, which returns the cached matrix whenever `_currentRenderId` still matches the scene's id. The scene advances that id *while rendering*, after `onBeforeRenderObservable` — so a simulation running in `beforeRender` sees ancestors exactly as they were during the previous frame.

`center()` (`render.ts:150`) reparents every mesh under a fresh root and rescales it, and runs right after `simulation.start()` with no render in between. So chain seeding computed each bone's world position from **pre-`center()`** ancestor matrices, placing the tail ~1.3 units from where the bone actually lands once the frame renders. The next frame turned that gap into velocity.

Demonstrated directly — move an ancestor with no intervening render:

| | bone world Y |
|---|---|
| before the ancestor moves | 0.6093 |
| after `node.computeWorldMatrix(true)` | 0.6093 (unchanged — stale) |
| after a real render | −0.3907 (correct) |

It is timing-dependent: when assets are cached the whole load completes inside one frame gap and a render happens to land between `center()` and the first seed, leaving the caches already refreshed. It only bites when loading spans several rendered frames — the cold path users hit.

A second, smaller discontinuity sits on top: `Preview.tsx:109` starts the emote from a React effect, several frames after the springs first seed, so the rig jumps from its bind pose to the emote's first frame in one step. Worth 15° on its own.

## Fix

All contained in `springBones.ts`; no caller changes.

- **`refreshWorldMatrix()`** walks the parent chain and recomputes top down before the seed reads any world position, so the seed uses the transform the frame will actually draw. This is the fix for the reported bug.
- **Tails and `boneLength` are seeded on the first simulated frame** rather than in `buildChain()`, which runs before `center()` exists. `boneLength` is therefore measured at the final world scale (`0.186 → 0.132` on `punk`). `buildChain()` no longer touches world matrices at all — it only needs local transforms, which drops a matrix inversion and two forced recomputes.
- **`onAnimationGroupPlayObservable`** drops the `seeded` flag so each chain re-seeds after the bind-pose-to-emote jump.
- The NaN recovery path reuses the same `seedJointToRest()` helper instead of duplicating the math inline.

## Tests

No automated test added. The logic needs a live Babylon scene, and `NullEngine` reports `getDeltaTime() === 0`, which trips the early return at the top of `updateSimulation()` — the test would pass while asserting nothing. There is no existing coverage in `src/lib/babylon`.

Verified with temporary instrumentation (since removed) recording each chain's per-frame deviation from its rest orientation. Both checks force their condition explicitly, so neither depends on load timing:

| check | without the fix | with the fix |
|---|---|---|
| ancestor moves with no render, then seed | **172.65°** | **0.73°** |
| emote starts after the springs seeded | **15.04°** | **0.80°** |

Supporting measurements on `punk` + male avatar: peak after `center()` drops from 173.2° to 0.07–0.13° across the three chains, each seeded exactly once.

Springs stay responsive: the same replay with `emote=dance` builds smoothly from 0° to a 46.2° peak (17.8° mean) instead of snapping, and driving `Avatar_Head` directly deflects a chain to 26.1°.

Not covered: an ancestor teleporting mid-session (outside startup and emote start) still kicks the chains. `center()` runs once at startup and emote starts are handled, so nothing in the current app hits it; a general teleport guard would be a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)