### PR TITLE
fix: align Babylon spring bone response with the Unity renderer

### DIFF
--- a/src/lib/babylon/springBones.ts
+++ b/src/lib/babylon/springBones.ts
@@ -3,8 +3,13 @@ import { SpringBoneParams } from '@dcl/schemas'
 
 const SPRING_BONE_PREFIX = 'springbone'
 const MAX_CHAINS_PER_WEARABLE = 12
-const MAX_JOINTS_PER_CHAIN = 12
+const MAX_JOINTS_PER_CHAIN = 8
 const MAX_DELTA_TIME = 0.05 // 50ms cap to prevent physics explosion after tab backgrounding
+
+// Physics runs at a fixed 60 Hz, decoupled from render fps, so authored stiffness/drag produce
+// identical motion on any display. Mirrors the Unity renderer's SpringBoneService.
+const FIXED_STEP = 1 / 60
+const MAX_SUBSTEPS = 4
 
 const SPRING_BONE_STIFFNESS_MIN = 0
 const SPRING_BONE_STIFFNESS_MAX = 4
@@ -181,10 +186,7 @@ function buildChain(root: TransformNode, scene: Scene, params: SpringBoneParams)
   return { rootName: root.name, joints, params, centerNode }
 }
 
-function updateSimulation(chains: SpringChain[], scene: Scene): void {
-  const dt = Math.min(scene.getEngine().getDeltaTime() / 1000, MAX_DELTA_TIME)
-  if (dt <= 0) return
-
+function updateSimulation(chains: SpringChain[], dt: number): void {
   for (const chain of chains) {
     const { params, centerNode } = chain
 
@@ -246,8 +248,11 @@ function updateSimulation(chains: SpringChain[], scene: Scene): void {
       Vector3.TransformNormalToRef(joint.boneAxis, _scratchMatrixB, _scratchVec3B) // reuse B as restTailDir
       const restTailDirLen = _scratchVec3B.length()
       if (restTailDirLen > 0) _scratchVec3B.scaleInPlace(1 / restTailDirLen)
-      // Stiffness pushes tail along the rest direction
-      _scratchVec3B.scaleToRef(stiffness * dt * joint.boneLength, _scratchVec3E)
+      // Stiffness pushes tail along the rest direction. The impulse is in world units, not scaled
+      // by bone length: the restoring rate a joint feels is stiffness/boneLength, so short hair
+      // bones snap back harder. Scaling by boneLength here would make it length-invariant and far
+      // floppier than the Unity renderer.
+      _scratchVec3B.scaleToRef(stiffness * dt, _scratchVec3E)
       _scratchVec3D.addInPlace(_scratchVec3E)
 
       // 3. Gravity
@@ -319,6 +324,7 @@ export class SpringBoneSimulation {
   private containers = new Map<string, AssetContainer>()
   private beforeRenderCallback: (() => void) | null = null
   private scene: Scene | null = null
+  private accumulatedDt = 0
 
   registerWearable(
     scene: Scene,
@@ -412,9 +418,19 @@ export class SpringBoneSimulation {
     this.scene = scene
 
     this.beforeRenderCallback = () => {
-      for (const chains of this.wearables.values()) {
-        updateSimulation(chains, scene)
+      this.accumulatedDt += Math.min(scene.getEngine().getDeltaTime() / 1000, MAX_DELTA_TIME)
+
+      let steps = 0
+      while (this.accumulatedDt >= FIXED_STEP && steps < MAX_SUBSTEPS) {
+        for (const chains of this.wearables.values()) {
+          updateSimulation(chains, FIXED_STEP)
+        }
+        this.accumulatedDt -= FIXED_STEP
+        steps++
       }
+
+      // Drop residual after a stall to avoid a spiral of death
+      if (steps === MAX_SUBSTEPS) this.accumulatedDt = 0
     }
 
     scene.registerBeforeRender(this.beforeRenderCallback)
@@ -428,5 +444,6 @@ export class SpringBoneSimulation {
     this.wearables.clear()
     this.containers.clear()
     this.scene = null
+    this.accumulatedDt = 0
   }
 }

--- a/src/lib/babylon/springBones.ts
+++ b/src/lib/babylon/springBones.ts
@@ -449,6 +449,7 @@ export class SpringBoneSimulation {
   start(scene: Scene): void {
     if (this.beforeRenderCallback) return
     this.scene = scene
+    this.accumulatedDt = 0
 
     // Starting an animation teleports the rig from its bind pose to the animation's first frame.
     // Re-seed after that jump, otherwise the springs read it as velocity and swing into place.


### PR DESCRIPTION
## Problem

Wearables with spring bones — Hair Punk, Double bun, piggy tails, two tails — were far more sensitive to avatar movement in the Babylon preview (`unity=false`) than in the Unity one (`unity=true`), even though both renderers receive identical params. The Unity behaviour is the expected one.

Repro: open the item editor with a spring-bone hairstyle equipped and play an emote, then flip `unity` in `CenterPanel.tsx` and compare.

## Cause

`updateSimulation` in `src/lib/babylon/springBones.ts` scaled the stiffness impulse by bone length:

```ts
_scratchVec3B.scaleToRef(stiffness * dt * joint.boneLength, _scratchVec3E)
```

aang-renderer's `SpringBoneSimulator.SimulateSlot` applies it in world units, with no length term:

```csharp
float3 stiffnessForce = math.mul(math.mul(parentRotation, config.LocalRotation), config.BoneAxis)
                        * config.Stiffness * deltaTime;
```

Because the tail is clamped back to `boneLength` immediately afterwards, the *angular* restoring rate a joint feels is `stiffness * dt / boneLength`. Multiplying by `boneLength` therefore made the restoring force length-invariant and much weaker than Unity's. Hair Punk's spring bones measure 0.176 world units, so the force was ~5.7× too weak. Gravity (`gravityDir * gravityPower * dt`) was already in absolute units on both sides, which is what made the mismatch asymmetric.

Params themselves were never the issue — `unity/physics.ts` forwards them unmodified, and the clamps in `springBones.ts` match the builder's slider ranges.

## Fix

- Drop the `boneLength` factor from the stiffness impulse so it matches Unity's world-unit formulation.
- Step physics at a fixed 60 Hz with an accumulator and a 4-substep cap, mirroring `SpringBoneService.Simulate`. Integrating with the raw frame delta made authored stiffness/drag behave differently on high-refresh-rate displays.
- Lower `MAX_JOINTS_PER_CHAIN` from 12 to 8 to match Unity's `MAX_JOINTS_PER_SPRING`, so long chains stop swaying further down the hierarchy than they do in Unity.

One intentional difference remains: Babylon supports `params.center` (center-space Verlet) and Unity parses but ignores it. It isn't a factor here — the builder defaults `center` to `undefined` and these hairstyles don't set it.

## Tests

No new automated tests — the simulation has no existing harness and is validated against the live renderer. Existing suite passes (`npm test`, 23 tests, 3 files).

Verified by driving the Babylon engine deterministically (constant 16.67 ms delta, reset to animation frame 0, manual `scene.render()` steps), measuring max deviation of Hair Punk's spring joints from their rest pose over 300 frames. Runs were bit-identical across repeats.

| emote | before | after |
|---|---|---|
| jump | mean 88.6°, peak 165° | mean 19.5°, peak 63° |
| dance | mean 13.5°, peak 40.3° | mean 3.4°, peak 26.6° |

At the same animation frame (dance, frame 257) the mohawk goes from 39.8° — visibly folded over — to 6.3°, a slight lean.

Not verified: a live side-by-side against `unity=true`. The browser automation available in this session runs tabs backgrounded, which pauses `requestAnimationFrame` and freezes both renderers, so the final eyeball comparison is still worth doing manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)