### PR TITLE
fix: forward only caller-requested avatar colors to the Unity renderer

### DIFF
--- a/src/hooks/useUnityConfig.ts
+++ b/src/hooks/useUnityConfig.ts
@@ -73,7 +73,11 @@ const getRequestedType = (type: PreviewType | null | undefined): PreviewType | n
 
 // The renderer already resolves the profile's own colors, and falls back to its own defaults when a
 // color is left unset, so only a color the caller actually asked for has to travel.
-const toColorOverride = (color: string | null | undefined): string | null => (color ? parseHex(color) : null)
+const toColorOverride = (color: string | null | undefined): string | null => {
+  if (!color) return null
+  const parsed = parseHex(color)
+  return parsed || null
+}
 
 // Convert potentially null/undefined values to string or empty string
 const toQueryValue = (value: string | null | undefined): string => value || ''

--- a/src/hooks/useUnityConfig.ts
+++ b/src/hooks/useUnityConfig.ts
@@ -8,12 +8,11 @@ import {
   WearableDefinition,
   EmoteDefinition,
   PreviewType,
-  Avatar,
   PreviewUnityMode,
 } from '@dcl/schemas'
 import { SocialEmoteAnimation } from '@dcl/schemas/dist/dapps/preview/social-emote-animation'
 import { config } from '../config'
-import { colorToHex, formatHex } from '../lib/color'
+import { parseHex } from '../lib/color'
 import { fetchItemFromContract, fetchProfile, fetchProfileEntity, sanitizeProfile } from '../lib/config'
 import { useOptions } from './useOptions'
 import { isWearable } from '../lib/wearable'
@@ -30,13 +29,13 @@ export interface UnityPreviewConfig {
   contract: string | null
   disableLoader: boolean
   emote: string | null
-  eyeColor: string
-  hairColor: string
+  eyeColor: string | null
+  hairColor: string | null
   item: string | null
   profile: string | null
   projection: PreviewProjection | null
   showAnimationReference: boolean | null
-  skinColor: string
+  skinColor: string | null
   token: string | null
   urn: string[] | null
   itemDefinition: WearableDefinition | EmoteDefinition | null
@@ -47,12 +46,6 @@ interface Background {
   color: string
   transparent: boolean
   image?: string
-}
-
-interface AvatarColors {
-  eyes: string
-  hair: string
-  skin: string
 }
 
 type QueryParams = {
@@ -78,14 +71,9 @@ type QueryParams = {
 const getRequestedType = (type: PreviewType | null | undefined): PreviewType | null =>
   type === PreviewType.AVATAR || type === PreviewType.WEARABLE ? type : null
 
-const getDefaultColors = (
-  profile: Avatar | null,
-  options: { eyes?: string | null; hair?: string | null; skin?: string | null },
-): AvatarColors => ({
-  eyes: formatHex(options.eyes || (profile?.avatar?.eyes?.color && colorToHex(profile.avatar.eyes.color)) || '#000000'),
-  hair: formatHex(options.hair || (profile?.avatar?.hair?.color && colorToHex(profile.avatar.hair.color)) || '#000000'),
-  skin: formatHex(options.skin || (profile?.avatar?.skin?.color && colorToHex(profile.avatar.skin.color)) || '#cc9b76'),
-})
+// The renderer already resolves the profile's own colors, and falls back to its own defaults when a
+// color is left unset, so only a color the caller actually asked for has to travel.
+const toColorOverride = (color: string | null | undefined): string | null => (color ? parseHex(color) : null)
 
 // Convert potentially null/undefined values to string or empty string
 const toQueryValue = (value: string | null | undefined): string => value || ''
@@ -208,11 +196,9 @@ export function useUnityConfig(): [UnityPreviewConfig | null, boolean, string | 
         }
 
         // Get colors
-        const { eyes, hair, skin } = getDefaultColors(profile, {
-          eyes: options.eyes,
-          hair: options.hair,
-          skin: options.skin,
-        })
+        const eyes = toColorOverride(options.eyes)
+        const hair = toColorOverride(options.hair)
+        const skin = toColorOverride(options.skin)
 
         // Get camera settings
         const mode = options.unityMode || null
@@ -242,11 +228,11 @@ export function useUnityConfig(): [UnityPreviewConfig | null, boolean, string | 
           contract: options.contractAddress || null,
           disableLoader: options.disableLoader || false,
           emote: emote?.toString() || null,
-          eyeColor: eyes.replace('#', ''),
-          hairColor: hair.replace('#', ''),
+          eyeColor: eyes,
+          hairColor: hair,
           item: options.itemId || null,
           profile: profileValue || null,
-          skinColor: skin.replace('#', ''),
+          skinColor: skin,
           token: options.tokenId || null,
           urn: options.urns || null,
           showAnimationReference: null,
@@ -278,9 +264,9 @@ export function useUnityConfig(): [UnityPreviewConfig | null, boolean, string | 
                 disableLoader: options.disableLoader ? 'true' : '',
                 profile: toQueryValue(profileValue || ''),
                 bodyShape: toQueryValue(bodyShape || ''),
-                eyeColor: toQueryColor(eyes || ''),
-                hairColor: toQueryColor(hair || ''),
-                skinColor: toQueryColor(skin || ''),
+                eyeColor: toQueryValue(eyes),
+                hairColor: toQueryValue(hair),
+                skinColor: toQueryValue(skin),
                 mode: toQueryValue(mode || ''),
                 camera,
                 projection,


### PR DESCRIPTION
## Problem

With `unity=true&mode=marketplace`, the `skin` / `hair` / `eyes` options are not honoured, so a
consumer can't let a user try color combinations on an avatar the way builder mode allows. The
renderer-side half of that is decentraland/aang-renderer#76; **this PR is the wrapper half and
depends on it.**

Repro: `…/?unity=true&mode=marketplace&profile=default1&skin=%23ff0000` renders `default1`'s own skin.

## Cause

Two halves. The renderer ignored the params (see the companion PR). The wrapper also had a latent
problem that would turn that fix into a regression: `getDefaultColors` in `useUnityConfig.ts` never
returned "unset", so `skinColor=cc9b76&hairColor=000000&eyeColor=000000` was written into the URL the
renderer parses **even when the caller asked for no color and no profile was fetched**. Harmless
while marketplace mode ignored it — but once honoured, every marketplace preview without a `profile`
param (the common PDP case: `contract` + `item`) would render the renderer's fallback `default1`
avatar with black hair and eyes instead of its own `#DDB18F` / `#985F38` / `#1C1C1C`.

## Fix

Forward only a color the caller actually asked for. The profile-derived branch was dead weight: when
`profile=` is set the renderer fetches that same profile and already uses its colors, and the
renderer falls back to its own defaults for anything left unset (the `#cc9b76` builder skin default
moves there in the companion PR). `getDefaultColors` and `toQueryColor` are gone; `parseHex` from
`src/lib/color.ts` normalizes `#ff0000` and `ff0000` alike. Net −14 lines.

The three `UnityPreviewConfig` color fields become `string | null`; they feed nothing but the query
params, and `updateQueryParams` already drops empty values.

## Tests

No test harness exists for `useUnityConfig` (only `src/lib/babylon/*.test.ts`) and the remaining
logic is a ternary, so no unit test was added. Verified against a dev server, reading back the
rewritten URL:

| URL | Result |
| --- | --- |
| `?unity=true&mode=marketplace&profile=default1` | colors absent, `bodyShape=BaseFemale` from the profile |
| `…&skin=%23ff0000&hair=00ff00&eyes=%230000ff` | `skinColor=ff0000&hairColor=00ff00&eyeColor=0000ff` |
| `?unity=true&mode=marketplace&urn=…standard_hair` (no profile) | colors absent — previously `cc9b76`/`000000`/`000000` |

`npx vitest run` — 23 passed. `prettier --check` clean. `tsc --noEmit` reports no new errors (the
pre-existing ones in `WebGPUWarning.tsx`, `src/config/index.ts` and `src/lib/scene.ts` are untouched
by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)